### PR TITLE
Lazy regrid + utils

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-me: CI Tests
+name: CI Tests
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,63 @@
+me: CI Tests
+
+permissions:
+  pull-requests: write
+  contents: write
+  packages: write
+
+on: [push, pull_request, workflow_call]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: "latest"
+          environment-name: grid-doctor
+          cache-environment: false
+          cache-downloads: false
+          create-args: >-
+            python=${{ matrix.python-version }}
+            gdal
+            rasterio
+            h5py
+            h5netcdf
+            hdf5
+            netcdf4
+            pip
+            cfgrib
+            xarray
+            cffi
+          condarc: |
+            channels:
+              - conda-forge
+            channel_priority: strict
+          init-shell: bash
+
+      - name: Install Python packages
+        shell: bash -l {0}
+        run: |
+          python -m pip install -e .[dev]
+
+      - name: Show environment
+        shell: bash -l {0}
+        run: |
+          micromamba list
+          pip list
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: pytest
+
+

--- a/src/grid_doctor/__init__.py
+++ b/src/grid_doctor/__init__.py
@@ -7,5 +7,6 @@ Your lat/lon data goes to rehab and comes out HEALed.
 __version__ = "2602.0.0"
 
 from .helpers import latlon_to_healpix_pyramid, save_pyramid_to_s3
+from .utils import cached_open_dataset
 
-__all__ = ["save_pyramid_to_s3", "latlon_to_healpix_pyramid"]
+__all__ = ["save_pyramid_to_s3", "latlon_to_healpix_pyramid", "cached_open_dataset"]

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -318,79 +318,50 @@ def regrid_to_healpix(
     src_points = np.column_stack([src_lat_2d.ravel(), src_lon_2d.ravel()])
     target_points = np.column_stack([hp_lat, hp_lon])
 
-    # Regrid each variable
+    # Regrid whole dataset
+    # Get axis positions for spatial dims
+    # Move spatial dims to the end
+    def regrid_core(src_2d, src_points, target_points, method, npix):
+        src_values = src_2d.ravel()
+        valid_mask = ~np.isnan(src_values)
+
+        if valid_mask.sum() == 0:
+            return np.full(npix, np.nan, dtype=src_2d.dtype)
+
+        return griddata(
+            src_points[valid_mask],
+            src_values[valid_mask],
+            target_points,
+            method=method,
+            fill_value=np.nan,
+        )
+
     regridded_vars = {}
     for var in ds.data_vars:
-        da = ds[var]
-
-        # Check if variable has spatial dimensions
-        if y_dim not in da.dims or x_dim not in da.dims:
-            # Skip non-spatial variables (don't include them)
-            continue
-
-        # Get non-spatial dimensions
-        other_dims = [d for d in da.dims if d not in (y_dim, x_dim)]
-
-        # Load data if dask array
-        data = da.values
-
-        # Get axis positions for spatial dims
-        y_axis = da.dims.index(y_dim)
-        x_axis = da.dims.index(x_dim)
-
-        # Move spatial dims to the end
-        axes_to_move = sorted([y_axis, x_axis])
-        data = np.moveaxis(data, axes_to_move, [-2, -1])
-
-        # Reshape to (batch, y, x)
-        batch_shape = data.shape[:-2]
-        n_batch = int(np.prod(batch_shape)) if batch_shape else 1
-        data_flat = data.reshape(n_batch, data.shape[-2], data.shape[-1])
-
-        # Interpolate each batch
-        regridded_flat = []
-        for i in range(n_batch):
-            src_values = data_flat[i].ravel()
-
-            # Handle NaN values - griddata doesn't like them
-            valid_mask = ~np.isnan(src_values)
-            if valid_mask.sum() == 0:
-                # All NaN, return NaN array
-                regridded_flat.append(np.full(npix, np.nan))
-            else:
-                regridded = griddata(
-                    src_points[valid_mask],
-                    src_values[valid_mask],
-                    target_points,
-                    method=method,
-                    fill_value=np.nan,
-                )
-                regridded_flat.append(regridded)
-
-        regridded_data = np.stack(regridded_flat, axis=0)
-
-        # Reshape back: (other_dims..., cell)
-        if batch_shape:
-            regridded_data = regridded_data.reshape(*batch_shape, npix)
-        else:
-            regridded_data = regridded_data.squeeze(axis=0)
-
-        # Create new DataArray with cell dimension
-        new_dims = list(other_dims) + ["cell"]
-        new_coords = {d: ds.coords[d] for d in other_dims if d in ds.coords}
-
-        regridded_vars[var] = xr.DataArray(
-            regridded_data,
-            dims=new_dims,
-            coords=new_coords,
-            attrs=da.attrs,
+        regridded_vars[var] = xr.apply_ufunc(
+            regrid_core,
+            ds[var],
+            input_core_dims=[[y_dim, x_dim]],
+            output_core_dims=[["cell"]],
+            kwargs=dict(
+                src_points=src_points,
+                target_points=target_points,
+                method=method,
+                npix=npix,
+            ),
+            vectorize=True,
+            dask="parallelized",
+            output_dtypes=ds[var].dtype,
+            dask_gufunc_kwargs={
+                "output_sizes": {"cell": npix},
+            },
         )
 
     # Build output dataset (only regridded variables)
     ds_hp = xr.Dataset(regridded_vars)
 
     # Copy relevant global attributes
-    ds_hp.attrs = {k: v for k, v in ds.attrs.items()}
+    ds_hp.attrs |= ds.attrs
 
     # Add HEALPix coordinates
     ds_hp = ds_hp.assign_coords(

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -336,7 +336,11 @@ def regrid_to_healpix(
     regridded_vars = {}
     # Regrid each variable individually
     # since they might have different dtypes
-    for var in ds.data_vars:
+    for var, da in ds.data_vars.items():
+        if not {y_dim, x_dim}.issubset(da.dims):
+            print(f"Skipping regridding for {var} ({y_dim,x_dim}) not in its dimensions")
+            continue
+
         regridded_vars[var] = xr.apply_ufunc(
             regrid_core,
             ds[var],

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -318,9 +318,6 @@ def regrid_to_healpix(
     src_points = np.column_stack([src_lat_2d.ravel(), src_lon_2d.ravel()])
     target_points = np.column_stack([hp_lat, hp_lon])
 
-    # Regrid whole dataset
-    # Get axis positions for spatial dims
-    # Move spatial dims to the end
     def regrid_core(src_2d, src_points, target_points, method, npix):
         src_values = src_2d.ravel()
         valid_mask = ~np.isnan(src_values)
@@ -337,6 +334,8 @@ def regrid_to_healpix(
         )
 
     regridded_vars = {}
+    # Regrid each variable individually
+    # since they might have different dtypes
     for var in ds.data_vars:
         regridded_vars[var] = xr.apply_ufunc(
             regrid_core,

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -338,7 +338,9 @@ def regrid_to_healpix(
     # since they might have different dtypes
     for var, da in ds.data_vars.items():
         if not {y_dim, x_dim}.issubset(da.dims):
-            print(f"Skipping regridding for {var} ({y_dim,x_dim}) not in its dimensions")
+            print(
+                f"Skipping regridding for {var} ({y_dim, x_dim}) not in its dimensions"
+            )
             continue
 
         regridded_vars[var] = xr.apply_ufunc(
@@ -437,42 +439,33 @@ def coarsen_healpix(ds: xr.Dataset, target_level: int) -> xr.Dataset:
             coarsened_vars[var] = da
             continue
 
-        other_dims = [d for d in da.dims if d != "cell"]
+        da = da.chunk({"cell": -1})
 
-        if not other_dims:
-            # Simple 1D case
-            coarse_data = hp.ud_grade(
-                da.values,
+
+        def _ud_grade(x):
+            return hp.ud_grade(
+                x,
                 target_nside,
                 order_in="NESTED" if is_nested else "RING",
                 order_out="NESTED" if is_nested else "RING",
             )
-            coarsened_vars[var] = xr.DataArray(
-                coarse_data, dims=["cell"], attrs=da.attrs
-            )
-        else:
-            # Multi-dimensional: iterate over other dimensions
-            da_stacked = da.stack(other=other_dims)
-            coarse_maps = []
 
-            for i in range(da_stacked.sizes["other"]):
-                coarse_map = hp.ud_grade(
-                    da_stacked.isel(other=i).values,
-                    target_nside,
-                    order_in="NESTED" if is_nested else "RING",
-                    order_out="NESTED" if is_nested else "RING",
-                )
-                coarse_maps.append(coarse_map)
+        coarse_da = xr.apply_ufunc(
+            _ud_grade,
+            da,
+            input_core_dims=[["cell"]],
+            output_core_dims=[["cell"]],
+            exclude_dims={"cell"},
+            output_dtypes=[da.dtype],
+            dask_gufunc_kwargs={
+                "output_sizes": {"cell": npix_target},
+            },
+            vectorize=True,
+            dask="parallelized",
+            keep_attrs=True,
+        )
 
-            coarse_stacked = xr.DataArray(
-                np.stack(coarse_maps, axis=-1),
-                dims=["cell", "other"],
-                coords={"other": da_stacked.coords["other"]},
-            ).unstack("other")
-
-            coarsened_vars[var] = coarse_stacked.transpose(*da.dims).assign_attrs(
-                da.attrs
-            )
+        coarsened_vars[var] = coarse_da
 
     # Build output dataset
     ds_coarse = xr.Dataset(coarsened_vars, attrs=ds.attrs.copy())

--- a/src/grid_doctor/utils.py
+++ b/src/grid_doctor/utils.py
@@ -1,0 +1,57 @@
+import hashlib
+import logging
+import numpy as np
+import pickle
+import tempfile
+import xarray as xr
+from os import environ
+from pathlib import Path
+
+
+
+
+def cache_dir() -> Path:
+    """
+    Returns the Path used for caching. 
+    Tries setting a cache directory in `/scratch` setting `TMPDIR` accordingly.
+    Otherwise fallsback to `tempfile.gettempdir()`.
+    """
+    scratch = Path('/scratch/{0:.1}/{0}'.format(environ['USER']))
+    if scratch.is_dir():
+        scratch_temp = scratch / tempfile.gettempprefix()
+        try:
+            scratch_temp.mkdir(exist_ok=True,parents=True)
+        except PermissionError:
+            logging.error("Unable to create cache in /scratch, continuing with default")
+            pass
+        else:
+            environ['TMPDIR'] = str(scratch_temp)
+            return scratch_temp
+    return Path(tempfile.gettempdir)
+
+
+def cached_open_dataset(files, **kwargs):
+    """
+    Opens specified files as single dataset, caching the resulting xarray.Dataset using pickle.
+    """
+    h = hashlib.sha256()
+    h.update(np.sort(np.unique(files)).astype(bytes))
+    pickle_file = cache_dir() / f'{h.hexdigest()}.pickle'
+
+    if pickle_file.exists():
+        logging.debug("Loading dataset from %s", pickle_file)
+        with open(pickle_file,'rb') as f:
+            _ds = pickle.load(f)
+            return _ds
+
+    print(f"Opening dataset with {len(files)} files ..." +(" "*40), flush=True, end='\r')
+    from dask.diagnostics  import ProgressBar
+    with ProgressBar():
+        _kwargs  = {'parallel':True,'chunks':'auto'} | kwargs 
+        _ds = xr.open_mfdataset(files, **_kwargs)
+
+    with open(pickle_file,'wb') as f:
+        logging.debug("Saving dataset in %s", pickle_file)
+        pickle.dump(_ds, file=f)
+    return _ds
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+import numpy as np
+import dask.array as da
+import xarray as xr
+import pytest
+
+from typing import Literal, Dict
+
+def _xy_to_latlon(x, y, grid: Literal['regular','curvilinear'] = 'regular') -> Dict | None:
+    match grid:
+        case 'regular':
+            return {
+                "lat": np.linspace(-90, 90, len(x)),
+                "lon": np.linspace(0, 360, len(y), endpoint=False),
+            }
+        case 'curvilinear':
+            lon2d, lat2d = np.meshgrid(x, y)
+            return {
+                "lat": (('x','y'), lat2d + 5 * np.sin(np.deg2rad(lon2d))),
+                "lon": (('x','y'), lon2d + 2 * np.cos(np.deg2rad(lat2d))),
+            }
+
+    return None
+
+#@pytest.fixture
+@pytest.fixture
+def test_ds(request):
+    def _make_dataset(grid=Literal['regular','curvilinear']) -> xr.Dataset:
+        dims = {
+            "time": 4,
+            "level": 3,
+            "y": 512,
+            "x": 512,
+        }
+
+        shape = tuple(dims.values())
+        chunks = (1, 1, -1,-1)
+
+        y = np.linspace(-90, 90, dims["y"])
+        x = np.linspace(0, 360, dims["x"], endpoint=False)
+        coords = {
+            "time": np.arange(dims["time"]),
+            "level": np.arange(dims["level"]),
+        }
+        coords |= _xy_to_latlon(x,y, grid=grid)
+
+        ds = xr.Dataset(
+            {
+                "temperature": (
+                    dims.keys(),
+                    da.random.random(shape, chunks=chunks).astype("float32"),
+                ),
+                "pressure": (
+                    dims.keys(),
+                    (1000 + 50 * da.random.random(shape, chunks=chunks)).astype("float64"),
+                ),
+                "quality_flag": (
+                    dims.keys(),
+                    da.random.randint(0, 5, shape, chunks=chunks).astype("int16"),
+                ),
+                "land_mask": (
+                    dims.keys(),
+                    (da.random.random(shape, chunks=chunks) > 0.7),
+                ),
+            },
+            coords=coords,
+        )
+
+        return ds
+
+    return _make_dataset(grid = request.param)
+

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -1,0 +1,24 @@
+import pytest
+
+from grid_doctor.helpers import regrid_to_healpix
+
+@pytest.mark.parametrize(
+        "test_ds",
+        ["regular", "curvilinear"],
+        ids=["regular", "curvilinear"],
+        indirect=True,
+ )
+def test_regrid_to_healpix(test_ds):
+    hp_ds = regrid_to_healpix(test_ds, level=9)
+
+    assert all((hp_ds.attrs[k] == v for k, v in test_ds.attrs.items()))
+
+    assert len(test_ds.data_vars) == len(hp_ds.data_vars)
+
+    attrs_eq = lambda a, b: a.attrs == b.attrs
+    var_check = lambda v, l: l(test_ds[v], hp_ds[v])
+
+    dtype_eq = lambda a, b: a.dtype == b.dtype
+    for v in test_ds.data_vars:
+        assert var_check(v, attrs_eq)
+        assert var_check(v, dtype_eq)

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -1,13 +1,16 @@
 import pytest
 
-from grid_doctor.helpers import regrid_to_healpix
+from dask.array import Array as DaskArray
+
+from grid_doctor.helpers import regrid_to_healpix, latlon_to_healpix_pyramid
+
 
 @pytest.mark.parametrize(
-        "test_ds",
-        ["regular", "curvilinear"],
-        ids=["regular", "curvilinear"],
-        indirect=True,
- )
+    "test_ds",
+    ["regular", "curvilinear"],
+    ids=["regular", "curvilinear"],
+    indirect=True,
+)
 def test_regrid_to_healpix(test_ds):
     hp_ds = regrid_to_healpix(test_ds, level=9)
 
@@ -22,3 +25,17 @@ def test_regrid_to_healpix(test_ds):
     for v in test_ds.data_vars:
         assert var_check(v, attrs_eq)
         assert var_check(v, dtype_eq)
+
+
+@pytest.mark.parametrize(
+    "test_ds",
+    ["regular", "curvilinear"],
+    ids=["regular", "curvilinear"],
+    indirect=True,
+)
+def test_latlon_to_healpix_pyramid(test_ds):
+    hp_p = latlon_to_healpix_pyramid(test_ds)
+    for level, hp_ds in hp_p.items():
+        assert all((hp_ds.attrs[k] == v for k, v in test_ds.attrs.items()))
+        ## ensure all variables are dask.array.Array / lazy
+        assert all((isinstance(v.data, DaskArray) for v in hp_ds.data_vars.values()))


### PR DESCRIPTION
 - Changes `helpers.regrid_to_healpix` to do regridding lazily keeping the use of `scipy.interpolate.griddata`
   - Test it using syntetic datasets on regular and curvilinear grid
 - Adds `utils.cached_open_dataset` to be used on datasets with large amount of files

