### PR TITLE
Era5 script

### DIFF
--- a/scripts/era5/README.md
+++ b/scripts/era5/README.md
@@ -30,6 +30,7 @@ For each time frequency:
  - Else:
    - Launch jobs that write slices of the dataset (potencially in parallel)
 
+### Execution
 
 `scripts/era5/slum.sh` prints the commands that launch the 2 jobs. The first to initialize the dataset, the second to schedule all the tasks that will populate it. For this readon the **first should succeed before the second is triggered**
 

--- a/scripts/era5/README.md
+++ b/scripts/era5/README.md
@@ -1,0 +1,43 @@
+# ERA5 
+
+## Sources
+The source of the data is the outcome of Etor CMORization and postprocessing
+
+There is an alternative based on kerchunked data: https://gitlab.dkrz.de/data-infrastructure-services/era5-kerchunks/-/raw/main/main.yaml
+However 2023 was the last year for that source (to be confirmed)
+
+## Current state
+
+As a prove of concept only hourly temperature and precipitation were converted and there's no precipitation data for the first 6 hours
+
+https://gridlook.pages.dev/#https://s3.eu-dkrz-1.dkrz.cloud/icdc/healpix/era5.zarr
+
+As of now:
+ - `xr.interp` was used because the input grid is regular, but the `regrid` helper function should be used
+ - only max healpix level was generated
+ - `to_zarr` was used instead of `save_pyramid_to_s3`
+
+## Approach
+
+Open all the files that comprise the dataset via `open_mfdataset` and cache the resulting `xarray.Dataset`
+
+Regrid the dataset `lazily` using `xr.apply_ufunc`
+ - Might consider pickle at this stage as well
+
+If first time running: 
+ - Write metadata only first
+
+Else:
+ - Launch jobs that write slices of the dataset (potencially in parallel)
+
+
+### Improvements/Alternatives
+
+For this dataset it is possible to open and process the input files in a pipeline.
+The first file being processed creates the dataset and the subsequent ones append to it on the `time` dimension
+
+This approach might be benefic for cases were the ammount of input files is very large.
+
+
+
+

--- a/scripts/era5/README.md
+++ b/scripts/era5/README.md
@@ -10,26 +10,36 @@ However 2023 was the last year for that source (to be confirmed)
 
 As a prove of concept only hourly temperature and precipitation were converted and there's no precipitation data for the first 6 hours
 
-https://gridlook.pages.dev/#https://s3.eu-dkrz-1.dkrz.cloud/icdc/healpix/era5.zarr
+https://eu-dkrz-1.dkrz.cloud/browser/icdc/healpix/era5/
 
-As of now:
- - `xr.interp` was used because the input grid is regular, but the `regrid` helper function should be used
- - only max healpix level was generated
- - `to_zarr` was used instead of `save_pyramid_to_s3`
+https://gridlook.pages.dev/#https://s3.eu-dkrz-1.dkrz.cloud/icdc/healpix/era5/P1M/level_7
 
-## Approach
+### Approach
 
-Open all the files that comprise the dataset via `open_mfdataset` and cache the resulting `xarray.Dataset`
+For each time frequency:
 
-Regrid the dataset `lazily` using `xr.apply_ufunc`
- - Might consider pickle at this stage as well
+ - Open all the files that comprise the dataset via `open_mfdataset` and cache the resulting `xarray.Dataset`
 
-If first time running: 
- - Write metadata only first
+ - Regrid the dataset `lazily` using `xr.apply_ufunc`
+  - `scipy.scipy.griddata(method=nearest)` is used
+  - Might consider pickle at this stage as well
 
-Else:
- - Launch jobs that write slices of the dataset (potencially in parallel)
+ - If first time running: 
+   - Write metadata only first
 
+ - Else:
+   - Launch jobs that write slices of the dataset (potencially in parallel)
+
+
+`scripts/era5/slum.sh` prints the commands that launch the 2 jobs. The first to initialize the dataset, the second to schedule all the tasks that will populate it. For this readon the **first should succeed before the second is triggered**
+
+It is taking roughly 3 hours and 30 min (max 4:40) for a time slice of 1440 values to be written accross **all** time frequencies for each zoom level (0-7)
+
+
+## Discuss
+
+  - `lat_bnds` and `lon_bnds` aren't taken into account during the regridding, should they?
+  - Only variables with spacial dimensions are kept, should it apply to all?
 
 ### Improvements/Alternatives
 
@@ -37,7 +47,3 @@ For this dataset it is possible to open and process the input files in a pipelin
 The first file being processed creates the dataset and the subsequent ones append to it on the `time` dimension
 
 This approach might be benefic for cases were the ammount of input files is very large.
-
-
-
-

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -9,7 +9,7 @@ from glob import glob
 from itertools import chain
 from os import getenv
 
-from grid_doctor import cached_open_dataset
+from grid_doctor import cached_open_dataset, save_pyramid_to_s3, latlon_to_healpix_pyramid
 
 from typing import Iterable
 
@@ -53,14 +53,13 @@ class Era5Layout():
             yield files_chain, f"{self.store_url}/{iso_freq}"
 
 def convert(init=False, region={'time': slice(0,96)}):
+    import zarr
+    zarr.config.set(default_zarr_format=2)
     opts = {
-            'zarr_format': 2,
-            'storage_options': {
-                "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
-                "key": getenv("S3_KEY"), 
-                "secret": getenv("S3_SECRET"),
-                }
-            }
+        "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
+        "key": getenv("S3_KEY"), 
+        "secret": getenv("S3_SECRET"),
+    }
 
     for files_chain, dst_url in Era5Layout('s3://icdc/healpix/era5/'):
         files = list(files_chain)
@@ -73,18 +72,12 @@ def convert(init=False, region={'time': slice(0,96)}):
         logging.debug("%s", ds)
 
         logging.info("Converting to healpix")
-        ds_hp = ds.pipe(regrid).chunk({'time':48})
+        ds_hp = latlon_to_healpix_pyramid(ds.chunk({'time':48}))
         logging.debug("%s", ds)
         
         if init:
             logging.info("Initializing store %s", dst_url)
-            ds_hp.to_zarr(dst_url,
-                    mode = 'w',
-                    compute=False,
-                    **opts)
-            ds_hp[['lat','lon']].to_zarr(dst_url,
-                    mode = 'r+',
-                    **opts)
+            save_pyramid_to_s3(ds_hp, dst_url, mode='w',compute=False, s3_options=opts)
 
         else:
             region={
@@ -93,11 +86,12 @@ def convert(init=False, region={'time': slice(0,96)}):
                     }
 
             logging.info("Writting to existing store on region: %s", str(region))
-            ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
-                    mode = 'r+',
-                    region = region,
-                    **opts,
-                    )
+            save_pyramid_to_s3(ds_hp, dst_url, mode='r+', region=region, s3_options=opts)
+            #ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
+            #        mode = 'r+',
+            #        region = region,
+            #        **opts,
+            #        )
 
 
 def main():

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -1,0 +1,112 @@
+#! python3
+import numpy as np
+import healpy as hp
+import xarray as xr
+import logging
+
+from argparse import ArgumentParser
+from glob import glob
+from itertools import chain
+from os import getenv
+
+from grid_doctor import cached_open_dataset
+
+
+def regrid(ds) -> xr.Dataset:
+    from grid_doctor.helpers  import get_latlon_resolution, resolution_to_healpix_level
+    res = get_latlon_resolution(ds)
+    zoom = resolution_to_healpix_level(res)
+    nside = hp.order2nside(zoom)
+    pixels = np.arange(hp.nside2npix(nside))
+
+    hp_lon, hp_lat = hp.pix2ang(nside=nside, ipix=pixels, lonlat=True, nest=True)
+
+    crs = xr.DataArray(
+            name="crs",
+            data=np.nan,
+            attrs={
+                "grid_mapping_name": "healpix",
+                "healpix_nside": nside,
+                "healpix_order": "nest"
+                },
+            )
+
+    
+    return ds.drop_dims('bnds') \
+            .interp(lon=("cell", hp_lon),lat=("cell", hp_lat),) \
+            .assign(crs=crs) \
+            .assign_coords(cell=pixels)
+
+
+def convert(init=False, region={'time': slice(0,96)}):
+    pattern = "/work/bm1159/XCES/data4xces/reanalysis/reanalysis/ECMWF/IFS/ERA5/1hr/atmos/{0}/r1i1p1/{0}_1hr_reanalysis_era5_r1i1p1_*.nc"
+    files = list(
+        chain.from_iterable(
+            glob(pattern.format(var)) for var in ("tas", "pr")
+        )
+    )
+    
+    logging.info("Opening dataset from %s files", len(files))
+    ds = cached_open_dataset(files, engine='h5netcdf', parallel=False)
+    logging.debug("%s", ds)
+
+    logging.info("Converting to healpix")
+    ds_hp = ds.pipe(regrid).chunk({'time':48})
+    logging.debug("%s", ds)
+
+    opts = {
+        'zarr_format': 2,
+        'storage_options': {
+            "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
+            "key": getenv("S3_KEY"), 
+            "secret": getenv("S3_SECRET"),
+        }
+    }
+    
+    dst_url="s3://icdc/healpix/era5.zarr"
+    if init:
+        logging.info("Initializing store")
+        ds_hp.to_zarr(dst_url,
+                mode = 'w',
+                compute=False,
+                **opts)
+        ds_hp[['lat','lon']].to_zarr(dst_url,
+                mode = 'r+',
+                **opts)
+        
+    else:
+        region={
+                k: slice(v.start, min(v.stop,len(ds.time)), v.step)
+                for k,v in region.items()
+            }
+        
+        logging.info("Writting to existing store on region: %s", str(region))
+        ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
+            mode = 'r+',
+            region = region,
+            **opts,
+            )
+
+
+def main():
+    start_idx = int(getenv("SLURM_ARRAY_TASK_ID", 0))
+    parser = ArgumentParser()
+    parser.add_argument("--init", action="store_true")
+    parser.add_argument("--slice-size", default=48, type=int)
+    parser.add_argument("--start", default=start_idx, type=int)
+    parser.add_argument("--debug", action="store_true")
+
+    args = parser.parse_args()
+        
+    logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    if args.slice_size % 48:
+        print('slice-size must be a multiple of 48 (time chunk)')
+        exit(1)
+
+    region = {'time':slice(args.start * args.slice_size, (args.start+1) * args.slice_size)}
+    print(f"init={args.init}, region={region}")
+    convert(init=args.init, region=region)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -87,6 +87,14 @@ def convert(init=False, region={"time": slice(0, 96)}):
         ds = cached_open_dataset(files, engine="h5netcdf", parallel=False)
         logging.debug("%s", ds)
 
+        if region["time"].start > ds.time.size:
+            logging.warning(
+                "Region (%s) not overlapping with dataset (%s), skipping!",
+                region,
+                {"time": slice(0, ds.time.size)},
+            )
+            continue
+
         logging.info("Converting to healpix")
         ds_hp = latlon_to_healpix_pyramid(ds.chunk({"time": 48}))
         logging.debug("%s", ds)

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -11,6 +11,8 @@ from os import getenv
 
 from grid_doctor import cached_open_dataset
 
+from typing import Iterable
+
 
 def regrid(ds) -> xr.Dataset:
     from grid_doctor.helpers  import get_latlon_resolution, resolution_to_healpix_level
@@ -37,55 +39,65 @@ def regrid(ds) -> xr.Dataset:
             .assign(crs=crs) \
             .assign_coords(cell=pixels)
 
+class Era5Layout():
+    pattern = "/work/bm1159/XCES/data4xces/reanalysis/reanalysis/ECMWF/IFS/ERA5/{0}/atmos/{1}/r1i1p1/{1}_*{0}_reanalysis_era5_r1i1p1_*.nc"
+    freqMap = {'1hr':'PT1H','day':'P1D', 'mon':'P1M'} # ISO 8601
+    
+    def __init__(self, store_url: str, variables : Iterable[str] = ("tas", "pr")):
+        self.store_url = store_url.rstrip('/')
+        self.vars = variables
+
+    def __iter__(self) -> Iterator[Iterable[str], str]:
+        for _freq, iso_freq in self.freqMap.items():
+            files_chain = chain.from_iterable(glob(self.pattern.format(_freq, _var)) for _var in self.vars)
+            yield files_chain, f"{self.store_url}/{iso_freq}"
 
 def convert(init=False, region={'time': slice(0,96)}):
-    pattern = "/work/bm1159/XCES/data4xces/reanalysis/reanalysis/ECMWF/IFS/ERA5/1hr/atmos/{0}/r1i1p1/{0}_1hr_reanalysis_era5_r1i1p1_*.nc"
-    files = list(
-        chain.from_iterable(
-            glob(pattern.format(var)) for var in ("tas", "pr")
-        )
-    )
-    
-    logging.info("Opening dataset from %s files", len(files))
-    ds = cached_open_dataset(files, engine='h5netcdf', parallel=False)
-    logging.debug("%s", ds)
-
-    logging.info("Converting to healpix")
-    ds_hp = ds.pipe(regrid).chunk({'time':48})
-    logging.debug("%s", ds)
-
     opts = {
-        'zarr_format': 2,
-        'storage_options': {
-            "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
-            "key": getenv("S3_KEY"), 
-            "secret": getenv("S3_SECRET"),
-        }
-    }
-    
-    dst_url="s3://icdc/healpix/era5.zarr"
-    if init:
-        logging.info("Initializing store")
-        ds_hp.to_zarr(dst_url,
-                mode = 'w',
-                compute=False,
-                **opts)
-        ds_hp[['lat','lon']].to_zarr(dst_url,
-                mode = 'r+',
-                **opts)
-        
-    else:
-        region={
-                k: slice(v.start, min(v.stop,len(ds.time)), v.step)
-                for k,v in region.items()
+            'zarr_format': 2,
+            'storage_options': {
+                "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
+                "key": getenv("S3_KEY"), 
+                "secret": getenv("S3_SECRET"),
+                }
             }
+
+    for files_chain, dst_url in Era5Layout('s3://icdc/healpix/era5/'):
+        files = list(files_chain)
+        if len(files) == 0:
+            logging.warning("No files found to be written to %s", dst_url)
+            continue
+
+        logging.info("Opening dataset from %s files to be regrided to %s", len(files), dst_url)
+        ds = cached_open_dataset(files, engine='h5netcdf', parallel=False)
+        logging.debug("%s", ds)
+
+        logging.info("Converting to healpix")
+        ds_hp = ds.pipe(regrid).chunk({'time':48})
+        logging.debug("%s", ds)
         
-        logging.info("Writting to existing store on region: %s", str(region))
-        ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
-            mode = 'r+',
-            region = region,
-            **opts,
-            )
+        if init:
+            logging.info("Initializing store %s", dst_url)
+            ds_hp.to_zarr(dst_url,
+                    mode = 'w',
+                    compute=False,
+                    **opts)
+            ds_hp[['lat','lon']].to_zarr(dst_url,
+                    mode = 'r+',
+                    **opts)
+
+        else:
+            region={
+                    k: slice(v.start, min(v.stop,len(ds.time)), v.step)
+                    for k,v in region.items()
+                    }
+
+            logging.info("Writting to existing store on region: %s", str(region))
+            ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
+                    mode = 'r+',
+                    region = region,
+                    **opts,
+                    )
 
 
 def main():

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -9,13 +9,18 @@ from glob import glob
 from itertools import chain
 from os import getenv
 
-from grid_doctor import cached_open_dataset, save_pyramid_to_s3, latlon_to_healpix_pyramid
+from grid_doctor import (
+    cached_open_dataset,
+    save_pyramid_to_s3,
+    latlon_to_healpix_pyramid,
+)
 
 from typing import Iterable
 
 
 def regrid(ds) -> xr.Dataset:
-    from grid_doctor.helpers  import get_latlon_resolution, resolution_to_healpix_level
+    from grid_doctor.helpers import get_latlon_resolution, resolution_to_healpix_level
+
     res = get_latlon_resolution(ds)
     zoom = resolution_to_healpix_level(res)
     nside = hp.order2nside(zoom)
@@ -24,74 +29,82 @@ def regrid(ds) -> xr.Dataset:
     hp_lon, hp_lat = hp.pix2ang(nside=nside, ipix=pixels, lonlat=True, nest=True)
 
     crs = xr.DataArray(
-            name="crs",
-            data=np.nan,
-            attrs={
-                "grid_mapping_name": "healpix",
-                "healpix_nside": nside,
-                "healpix_order": "nest"
-                },
-            )
+        name="crs",
+        data=np.nan,
+        attrs={
+            "grid_mapping_name": "healpix",
+            "healpix_nside": nside,
+            "healpix_order": "nest",
+        },
+    )
 
-    
-    return ds.drop_dims('bnds') \
-            .interp(lon=("cell", hp_lon),lat=("cell", hp_lat),) \
-            .assign(crs=crs) \
-            .assign_coords(cell=pixels)
+    return (
+        ds.drop_dims("bnds")
+        .interp(
+            lon=("cell", hp_lon),
+            lat=("cell", hp_lat),
+        )
+        .assign(crs=crs)
+        .assign_coords(cell=pixels)
+    )
 
-class Era5Layout():
+
+class Era5Layout:
     pattern = "/work/bm1159/XCES/data4xces/reanalysis/reanalysis/ECMWF/IFS/ERA5/{0}/atmos/{1}/r1i1p1/{1}_*{0}_reanalysis_era5_r1i1p1_*.nc"
-    freqMap = {'1hr':'PT1H','day':'P1D', 'mon':'P1M'} # ISO 8601
-    
-    def __init__(self, store_url: str, variables : Iterable[str] = ("tas", "pr")):
-        self.store_url = store_url.rstrip('/')
+    freqMap = {"1hr": "PT1H", "day": "P1D", "mon": "P1M"}  # ISO 8601
+
+    def __init__(self, store_url: str, variables: Iterable[str] = ("tas", "pr")):
+        self.store_url = store_url.rstrip("/")
         self.vars = variables
 
     def __iter__(self) -> Iterator[Iterable[str], str]:
         for _freq, iso_freq in self.freqMap.items():
-            files_chain = chain.from_iterable(glob(self.pattern.format(_freq, _var)) for _var in self.vars)
+            files_chain = chain.from_iterable(
+                glob(self.pattern.format(_freq, _var)) for _var in self.vars
+            )
             yield files_chain, f"{self.store_url}/{iso_freq}"
 
-def convert(init=False, region={'time': slice(0,96)}):
+
+def convert(init=False, region={"time": slice(0, 96)}):
     import zarr
+
     zarr.config.set(default_zarr_format=2)
     opts = {
-        "endpoint_url":"https://s3.eu-dkrz-1.dkrz.cloud",
-        "key": getenv("S3_KEY"), 
+        "endpoint_url": "https://s3.eu-dkrz-1.dkrz.cloud",
+        "key": getenv("S3_KEY"),
         "secret": getenv("S3_SECRET"),
     }
 
-    for files_chain, dst_url in Era5Layout('s3://icdc/healpix/era5/'):
+    for files_chain, dst_url in Era5Layout("s3://icdc/healpix/era5/"):
         files = list(files_chain)
         if len(files) == 0:
             logging.warning("No files found to be written to %s", dst_url)
             continue
 
-        logging.info("Opening dataset from %s files to be regrided to %s", len(files), dst_url)
-        ds = cached_open_dataset(files, engine='h5netcdf', parallel=False)
+        logging.info(
+            "Opening dataset from %s files to be regrided to %s", len(files), dst_url
+        )
+        ds = cached_open_dataset(files, engine="h5netcdf", parallel=False)
         logging.debug("%s", ds)
 
         logging.info("Converting to healpix")
-        ds_hp = latlon_to_healpix_pyramid(ds.chunk({'time':48}))
+        ds_hp = latlon_to_healpix_pyramid(ds.chunk({"time": 48}))
         logging.debug("%s", ds)
-        
+
         if init:
             logging.info("Initializing store %s", dst_url)
-            save_pyramid_to_s3(ds_hp, dst_url, mode='w',compute=False, s3_options=opts)
+            save_pyramid_to_s3(ds_hp, dst_url, mode="w", compute=False, s3_options=opts)
 
         else:
-            region={
-                    k: slice(v.start, min(v.stop,len(ds.time)), v.step)
-                    for k,v in region.items()
-                    }
+            region = {
+                k: slice(v.start, min(v.stop, len(ds.time)), v.step)
+                for k, v in region.items()
+            }
 
             logging.info("Writting to existing store on region: %s", str(region))
-            save_pyramid_to_s3(ds_hp, dst_url, mode='r+', region=region, s3_options=opts)
-            #ds_hp.drop_vars(set(ds.dims)& set(ds.coords)).drop_vars(['crs', 'cell']).isel(region).to_zarr(dst_url,
-            #        mode = 'r+',
-            #        region = region,
-            #        **opts,
-            #        )
+            save_pyramid_to_s3(
+                ds_hp, dst_url, mode="r+", region=region, s3_options=opts
+            )
 
 
 def main():
@@ -103,16 +116,19 @@ def main():
     parser.add_argument("--debug", action="store_true")
 
     args = parser.parse_args()
-        
+
     logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
 
     if args.slice_size % 48:
-        print('slice-size must be a multiple of 48 (time chunk)')
+        print("slice-size must be a multiple of 48 (time chunk)")
         exit(1)
 
-    region = {'time':slice(args.start * args.slice_size, (args.start+1) * args.slice_size)}
+    region = {
+        "time": slice(args.start * args.slice_size, (args.start + 1) * args.slice_size)
+    }
     print(f"init={args.init}, region={region}")
     convert(init=args.init, region=region)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/era5/slurm.sh
+++ b/scripts/era5/slurm.sh
@@ -7,7 +7,7 @@ cat << EOF
 #! /bin/bash
 #SBATCH --mem=100GB
 #SBATCH --partition=shared
-#SBATCH --time=00:20:00
+#SBATCH --time=1-00:00:00
 
 srun python3 scripts/era5/convert.py --slice-size=\$1
 EOF

--- a/scripts/era5/slurm.sh
+++ b/scripts/era5/slurm.sh
@@ -13,15 +13,21 @@ srun python3 scripts/era5/convert.py --slice-size=\$1
 EOF
 }
 
-function run_tasks {
+function run_init {
+    echo srun --account=$(groups|cut -d' ' -f1) -p shared --mem=100GB --time=1-00:00:00 python3 scripts/era5/convert.py --init 
+}
+
+
+function run_update {
     local time_end=$(curl -sL https://s3.eu-dkrz-1.dkrz.cloud/icdc/healpix/era5.zarr/time/.zarray | jq '.shape[]')
     local slicesize=$(( 48 * 30 ))
     local tasks=$((time_end / slicesize))
     #tasks=1
-    makewrapper > wrapper.sh
-    echo "sbatch --account=$(groups|cut -d' ' -f1) -p shared --array=0-${tasks} wrapper.sh ${slicesize}"
+    makewrapper > era5wrapper.sh
+    echo "sbatch --account=$(groups|cut -d' ' -f1) -p shared --array=0-${tasks} era5wrapper.sh ${slicesize}"
 }
 
 
-run_tasks
+run_init
+run_update
 

--- a/scripts/era5/slurm.sh
+++ b/scripts/era5/slurm.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/bash
+
+set -e
+
+function makewrapper {
+cat << EOF
+#! /bin/bash
+#SBATCH --mem=100GB
+#SBATCH --partition=shared
+#SBATCH --time=00:20:00
+
+srun python3 scripts/era5/convert.py --slice-size=\$1
+EOF
+}
+
+function run_tasks {
+    local time_end=$(curl -sL https://s3.eu-dkrz-1.dkrz.cloud/icdc/healpix/era5.zarr/time/.zarray | jq '.shape[]')
+    local slicesize=$(( 48 * 30 ))
+    local tasks=$((time_end / slicesize))
+    #tasks=1
+    makewrapper > wrapper.sh
+    echo "sbatch --account=$(groups|cut -d' ' -f1) -p shared --array=0-${tasks} wrapper.sh ${slicesize}"
+}
+
+
+run_tasks
+

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -2,7 +2,7 @@
 grid-doctor: Convert lat/lon xarray datasets to HEALPix pyramids and save to S3.
 """
 
-from typing import Any, Literal, Optional, Tuple
+from typing import Any, Literal, Optional, Tuple, Union
 
 import healpy as hp
 import numpy as np
@@ -542,7 +542,9 @@ def save_pyramid_to_s3(
     pyramid: dict[int, xr.Dataset],
     s3_path: str,
     s3_options: dict[str, Any],
-    mode: Literal["a", "w"] = "a",
+    mode: Literal["a", "w", "r+"] = "a",
+    compute: bool = True,
+    region: Union[Literal["auto"], dict[str, slice]] = "auto",
 ) -> None:
     """Save HEALPix pyramid to S3 as Zarr stores.
 
@@ -566,7 +568,25 @@ def save_pyramid_to_s3(
         print(f"Saving level {level} to {level_path}")
 
         store = s3fs.S3Map(root=level_path, s3=fs)
-        ds.to_zarr(store, mode=mode)
+
+        if region == "auto":
+            ds.to_zarr(store, mode=mode, compute=compute)
+        else:
+            to_drop = (
+                set(
+                    n
+                    for n, v in ds.data_vars.items()
+                    if region.keys().isdisjoint(v.dims)
+                )
+                | set(ds.dims)
+                | set(ds.coords)
+            )
+            ds.drop_vars(to_drop, errors="warn").isel(region).to_zarr(
+                store, mode=mode, compute=compute, region=region
+            )
+
+        if mode == "w" and not compute:
+            ds[list(ds.coords)].to_zarr(store, mode="r+")
 
     print(f"Pyramid saved to {s3_path}")
 

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -314,24 +314,72 @@ def regrid_to_healpix(
     src_lon_2d = src_lon_2d % 360
     hp_lon = hp_lon % 360
 
-    # Flatten source coordinates for scipy.griddata
-    src_points = np.column_stack([src_lat_2d.ravel(), src_lon_2d.ravel()])
-    target_points = np.column_stack([hp_lat, hp_lon])
+    if method == "conservative":
+        # Compute cell areas
+        lat_bnds = ds["lat_bnds"].values
+        lon_bnds = ds["lon_bnds"].values % 360
+        if lat_bnds.ndim == 2 and lon_bnds.ndim == 2:
+            lat1 = np.deg2rad(lat_bnds[:, 0])
+            lat2 = np.deg2rad(lat_bnds[:, 1])
+            lon1 = np.deg2rad(lon_bnds[:, 0])
+            lon2 = np.deg2rad(lon_bnds[:, 1])
+            cell_area = np.abs(
+                (np.sin(lat2) - np.sin(lat1))[:, None] * (lon2 - lon1)[None, :]
+            )
+        else:
+            lat1 = np.deg2rad(lat_bnds[..., 0])
+            lat2 = np.deg2rad(lat_bnds[..., 1])
+            lon1 = np.deg2rad(lon_bnds[..., 0])
+            lon2 = np.deg2rad(lon_bnds[..., 1])
+            cell_area = np.abs((lon2 - lon1) * (np.sin(lat2) - np.sin(lat1)))
 
-    def regrid_core(src_2d, src_points, target_points, method, npix):
-        src_values = src_2d.ravel()
-        valid_mask = ~np.isnan(src_values)
+        theta = np.deg2rad(90.0 - src_lat_2d.ravel())
+        phi = np.deg2rad(src_lon_2d.ravel())
+        pix_index = hp.ang2pix(nside, theta, phi, nest=nest)
+        flat_area = cell_area.ravel()
 
-        if valid_mask.sum() == 0:
-            return np.full(npix, np.nan, dtype=src_2d.dtype)
+        def regrid_conservative_func(da):
+            values = da.ravel()
+            valid = ~np.isnan(values)
+            if valid.sum() == 0:
+                return np.full(npix, np.nan, dtype=da.dtype)
 
-        return griddata(
-            src_points[valid_mask],
-            src_values[valid_mask],
-            target_points,
-            method=method,
-            fill_value=np.nan,
-        )
+            weighted_sum = np.bincount(
+                pix_index[valid],
+                weights=values[valid] * flat_area[valid],
+                minlength=npix,
+            )
+            area_sum = np.bincount(
+                pix_index[valid],
+                weights=flat_area[valid],
+                minlength=npix,
+            )
+            out = weighted_sum / area_sum
+            out[area_sum == 0] = np.nan
+            return out
+
+        regrid_core = regrid_conservative_func
+    else:
+        # Flatten source coordinates for scipy.griddata
+        src_points = np.column_stack([src_lat_2d.ravel(), src_lon_2d.ravel()])
+        target_points = np.column_stack([hp_lat, hp_lon])
+
+        def regrid_interpolate_func(src_2d):
+            src_values = src_2d.ravel()
+            valid_mask = ~np.isnan(src_values)
+
+            if valid_mask.sum() == 0:
+                return np.full(npix, np.nan, dtype=src_2d.dtype)
+
+            return griddata(
+                src_points[valid_mask],
+                src_values[valid_mask],
+                target_points,
+                method=method,
+                fill_value=np.nan,
+            )
+
+        regrid_core = regrid_interpolate_func
 
     regridded_vars = {}
     # Regrid each variable individually
@@ -348,12 +396,6 @@ def regrid_to_healpix(
             ds[var],
             input_core_dims=[[y_dim, x_dim]],
             output_core_dims=[["cell"]],
-            kwargs=dict(
-                src_points=src_points,
-                target_points=target_points,
-                method=method,
-                npix=npix,
-            ),
             vectorize=True,
             dask="parallelized",
             output_dtypes=ds[var].dtype,
@@ -498,6 +540,7 @@ def create_healpix_pyramid(
     ds: xr.Dataset,
     max_level: int,
     min_level: int = 0,
+    **kwargs,
 ) -> dict[int, xr.Dataset]:
     """Create HEALPix pyramid from max_level down to min_level.
 
@@ -522,7 +565,7 @@ def create_healpix_pyramid(
         f"Regridding to HEALPix level {max_level} "
         f"(NSIDE={2**max_level}, npix={12 * 4**max_level})"
     )
-    ds_hp = regrid_to_healpix(ds, max_level)
+    ds_hp = regrid_to_healpix(ds, max_level, **kwargs)
     pyramid[max_level] = ds_hp
 
     # Coarsen down to min_level
@@ -595,6 +638,7 @@ def latlon_to_healpix_pyramid(
     ds: xr.Dataset,
     min_level: int = 0,
     max_level: Optional[int] = None,
+    method: Literal["nearest", "linear", "conservative"] = "nearest",
 ) -> dict[int, xr.Dataset]:
     """Full pipeline: lat/lon dataset -> HEALPix pyramid.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import numpy as np
 import dask.array as da
 import xarray as xr
 import pytest
+import pandas as pd
 
 from typing import Literal, Dict
 
@@ -21,51 +22,106 @@ def _xy_to_latlon(x, y, grid: Literal['regular','curvilinear'] = 'regular') -> D
 
     return None
 
-#@pytest.fixture
+
+def era5(
+    start="1940-01-01",
+    end="2026-02-05T23:00:00",
+    freq="h",
+) -> xr.Dataset:
+    rand = da.random.random
+
+    time = pd.date_range(start, end, freq=freq)
+    lon = np.linspace(0.0, 359.71875, 1280)
+    lat = np.linspace(-89.78125, 89.78125, 640)
+    bnds = np.arange(2)
+
+    tas = rand(
+        (len(time), len(lat), len(lon)),
+        chunks=(40, 640, 1280),
+    ).astype("float32")
+
+    pr = rand(
+        (len(time), len(lat), len(lon)),
+        chunks=(39, 640, 1280),
+    ).astype("float32")
+
+    lon_bnds = rand(
+        (len(time), len(lon), 2),
+        chunks=(729, 1280, 2),
+    )
+
+    lat_bnds = rand(
+        (len(time), len(lat), 2),
+        chunks=(729, 640, 2),
+    )
+
+    ds = xr.Dataset(
+        data_vars={
+            "tas": (("time", "lat", "lon"), tas),
+            "pr": (("time", "lat", "lon"), pr),
+            "lon_bnds": (("time", "lon", "bnds"), lon_bnds),
+            "lat_bnds": (("time", "lat", "bnds"), lat_bnds),
+        },
+        coords={
+            "time": time,
+            "lon": lon,
+            "lat": lat,
+            "bnds": bnds,
+        },
+        attrs={
+            "description": "Synthetic dataset matching requested structure"
+        },
+    )
+
+    return ds
+
+def _make_dataset(grid=Literal['regular','curvilinear']) -> xr.Dataset:
+    dims = {
+        "time": 4,
+        "level": 3,
+        "y": 512,
+        "x": 512,
+    }
+
+    shape = tuple(dims.values())
+    chunks = (1, 1, -1,-1)
+
+    y = np.linspace(-90, 90, dims["y"])
+    x = np.linspace(0, 360, dims["x"], endpoint=False)
+    coords = {
+        "time": np.arange(dims["time"]),
+        "level": np.arange(dims["level"]),
+    }
+    coords |= _xy_to_latlon(x,y, grid=grid)
+
+    ds = xr.Dataset(
+        {
+            "temperature": (
+                dims.keys(),
+                da.random.random(shape, chunks=chunks).astype("float32"),
+            ),
+            "pressure": (
+                dims.keys(),
+                (1000 + 50 * da.random.random(shape, chunks=chunks)).astype("float64"),
+            ),
+            "quality_flag": (
+                dims.keys(),
+                da.random.randint(0, 5, shape, chunks=chunks).astype("int16"),
+            ),
+            "land_mask": (
+                dims.keys(),
+                (da.random.random(shape, chunks=chunks) > 0.7),
+            ),
+        },
+        coords=coords,
+    )
+
+    return ds
+    
 @pytest.fixture
 def test_ds(request):
-    def _make_dataset(grid=Literal['regular','curvilinear']) -> xr.Dataset:
-        dims = {
-            "time": 4,
-            "level": 3,
-            "y": 512,
-            "x": 512,
-        }
-
-        shape = tuple(dims.values())
-        chunks = (1, 1, -1,-1)
-
-        y = np.linspace(-90, 90, dims["y"])
-        x = np.linspace(0, 360, dims["x"], endpoint=False)
-        coords = {
-            "time": np.arange(dims["time"]),
-            "level": np.arange(dims["level"]),
-        }
-        coords |= _xy_to_latlon(x,y, grid=grid)
-
-        ds = xr.Dataset(
-            {
-                "temperature": (
-                    dims.keys(),
-                    da.random.random(shape, chunks=chunks).astype("float32"),
-                ),
-                "pressure": (
-                    dims.keys(),
-                    (1000 + 50 * da.random.random(shape, chunks=chunks)).astype("float64"),
-                ),
-                "quality_flag": (
-                    dims.keys(),
-                    da.random.randint(0, 5, shape, chunks=chunks).astype("int16"),
-                ),
-                "land_mask": (
-                    dims.keys(),
-                    (da.random.random(shape, chunks=chunks) > 0.7),
-                ),
-            },
-            coords=coords,
-        )
-
-        return ds
-
-    return _make_dataset(grid = request.param)
+    if request.param == 'era5':
+        return era5()
+    else:
+        return _make_dataset(grid = request.param)
 

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -35,9 +35,34 @@ def test_regrid_to_healpix(test_ds):
     ids=["regular", "curvilinear", "era5"],
     indirect=True,
 )
-def test_latlon_to_healpix_pyramid(test_ds):
-    hp_p = latlon_to_healpix_pyramid(test_ds)
+@pytest.mark.parametrize(
+    "method",
+    ["nearest", "linear", "conservative"],
+    ids=["nearest", "linear", "conservative"],
+)
+def test_latlon_to_healpix_pyramid_lazy(test_ds, method):
+    hp_p = latlon_to_healpix_pyramid(test_ds, method=method)
     for level, hp_ds in hp_p.items():
         assert all((hp_ds.attrs[k] == v for k, v in test_ds.attrs.items()))
         ## ensure all variables are dask.array.Array / lazy
         assert all((isinstance(v.data, DaskArray) for v in hp_ds.data_vars.values()))
+
+
+@pytest.mark.parametrize(
+    "test_ds",
+    ["regular", "curvilinear", "era5"],
+    ids=["regular", "curvilinear", "era5"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "method",
+    ["nearest", "linear", "conservative"],
+    ids=["nearest", "linear", "conservative"],
+)
+def test_latlon_to_healpix_pyramid_global_mean(test_ds, method):
+    hp_p = latlon_to_healpix_pyramid(test_ds, method=method)
+
+    _, hp_ds = hp_p.popitem()
+
+    for name, var in hp_ds.data_vars.items():
+        meam = var.isel(time=0).mean().compute()

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -7,30 +7,32 @@ from grid_doctor.helpers import regrid_to_healpix, latlon_to_healpix_pyramid
 
 @pytest.mark.parametrize(
     "test_ds",
-    ["regular", "curvilinear"],
-    ids=["regular", "curvilinear"],
+    ["regular", "curvilinear", "era5"],
+    ids=["regular", "curvilinear", "era5"],
     indirect=True,
 )
 def test_regrid_to_healpix(test_ds):
     hp_ds = regrid_to_healpix(test_ds, level=9)
 
+    print(test_ds)
+    print(hp_ds)
     assert all((hp_ds.attrs[k] == v for k, v in test_ds.attrs.items()))
 
-    assert len(test_ds.data_vars) == len(hp_ds.data_vars)
+    assert set(test_ds.data_vars).issuperset(hp_ds.data_vars.keys())
 
     attrs_eq = lambda a, b: a.attrs == b.attrs
     var_check = lambda v, l: l(test_ds[v], hp_ds[v])
 
     dtype_eq = lambda a, b: a.dtype == b.dtype
-    for v in test_ds.data_vars:
+    for v in hp_ds.data_vars:
         assert var_check(v, attrs_eq)
         assert var_check(v, dtype_eq)
 
 
 @pytest.mark.parametrize(
     "test_ds",
-    ["regular", "curvilinear"],
-    ids=["regular", "curvilinear"],
+    ["regular", "curvilinear", "era5"],
+    ids=["regular", "curvilinear", "era5"],
     indirect=True,
 )
 def test_latlon_to_healpix_pyramid(test_ds):


### PR DESCRIPTION
This PR is rebased on `lazygrid`  since it requires the underlying lazy evaluation. The target branch ~can later be~ _was_ adjusted to `main` ~in case #1 gets merged before this one.~

Adds ERA5 scripts to write the regrided datasets into S3 and to submit the jobs in SLURM
Adds a `synthetic` dataset with the same layout as the ERA5 to the test fixtures to exercise the conversion