### PR TITLE
Lon padding

### DIFF
--- a/docs/waterpark.md
+++ b/docs/waterpark.md
@@ -10,6 +10,32 @@ them as multi-resolution Zarr pyramids from S3 object storage.  The unified grid
 enables efficient cross-dataset analysis, ML training pipelines, and interactive
 visualisation without per-dataset regridding at access time.
 
+
+### Currently available Datasets
+
+| Dataset | Public Bucket | Data Access via |
+|---------|---------------|-----------------|
+| [CMIP6](https://wcrp-cmip.org/cmip-phase-6-cmip6)   | <https://eu-dkrz-3.dkrz.cloud/browser/cmip6> | `https://s3.eu-dkrz-3.dkrz.cloud/cimp6` |
+| [DYAMOND](https://easy.gems.dkrz.de/DYAMOND/index.html)   | <https://eu-dkrz-3.dkrz.cloud/browser/dyamond> | `https://s3.eu-dkrz-3.dkrz.cloud/dyamond` |
+| [EERIE](https://dataviewer.eerie-project.eu/home/eddy-rich)   | <https://eu-dkrz-3.dkrz.cloud/browser/eerie> | `https://s3.eu-dkrz-3.dkrz.cloud/eerie` |
+| [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5)   | <https://eu-dkrz-3.dkrz.cloud/browser/era5> | `https://s3.eu-dkrz-3.dkrz.cloud/era5 `|
+| [ICDC](https://www.cen.uni-hamburg.de/en/icdc)   | <https://eu-dkrz-3.dkrz.cloud/browser/icdc> | `https://s3.eu-dkrz-3.dkrz.cloud/icdc` |
+| [ICON-DREAM](https://opendata.dwd.de/climate_environment/CDC/help/landing_pages/doi_landingpage_ICON-DREAM_v1-en.html)   | <https://eu-dkrz-3.dkrz.cloud/browser/icon-dream> | `https://s3.eu-dkrz-3.dkrz.cloud/icon-dream` |
+| [nextGEMS](https://nextgems-h2020.eu)   | <https://eu-dkrz-3.dkrz.cloud/browser/nextgems> | `https://s3.eu-dkrz-3.dkrz.cloud/nextgems` |
+| [ORCESTRA](https://orcestra-campaign.org/data.html)   | <https://eu-dkrz-3.dkrz.cloud/browser/orchestra> | `https://s3.eu-dkrz-3.dkrz.cloud/orchsestra`|
+
+!!! note
+    To browse the available datasets use the links in the Public Bucket columns,
+    `https://eu-dkrz-3.dkrz.cloud/browser/<bucket>`. To access the
+    data use the `https://s3.eu-dkrz-3.dkrz.cloud/<bucket>/<sub-dirs>/level_X.zarr`
+    for example
+
+    ```python
+    import xarray as xr
+
+    ds = xr.open_zarr("https://s3.eu-dkrz-3.dkrz.cloud/dyamond/icon-sap-5km/PT15M/level_9.zarr")
+    ```
+
 ---
 
 ## Remapping methodology
@@ -485,8 +511,8 @@ nanmean), not by repeated remapping.
     Suggestion: `<bucket>/healpix/<experiment-compaign>/<model>/<freq>/level_X.zarr"`
 
     Naming conventions can be quite different for different datasets, but we
-    can still aim at having a **fixed** number of directory levels. If this
-    fixed number won't guarantee unique paths the directory names themselves
+    can still aim at having a number **four** directory levels. If those
+    *four* levels don't guarantee unique paths the directory names themselves
     can be adjusted to from uniq name patterns such as:
 
     ```bash
@@ -503,14 +529,19 @@ nanmean), not by repeated remapping.
     target level. The weight files with their grid signature should be stored
     at the following location:
 
-    `/work/ks1387/healpix-weights`
+    ```console
+    ls /work/ks1387/healpix-weights
+
+    weights_0ba7e6dca9ba1ae9.nc  weights_3051722bc32a01e5.nc  weights_46fdfc6feb8ea520.nc  weights_d9c2730b22295f4a.nc
+    weights_2aff1785f62b0254.nc  weights_3a28f272e1fb6024.nc  weights_901fbfc4a3ce2458.nc
+    ```
 
     To make sure that the weight files are getting reproducible and reusable
     stored use `cache_path=/work/ks1387/healpix-weights` weights generation.
 
 !!! question "Zarr format: v2 or v3?"
 
-    The current visualisation tool (gridlook / zarina) requires Zarr v2.
+    Some clients  (gdal,  zarrita) still require Zarr v2.
     Zarr v3 is the future standard but ecosystem support is still
     catching up.
 

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -941,15 +941,20 @@ def _regular_grid_mesh(
     [`_infer_bounds_1d`][grid_doctor.remap_backend._infer_bounds_1d].
     No Python-level cell loops are used.
 
+    The caller must pass *lon* as a monotonic sequence (i.e. **not**
+    pre-canonicalised to ``[-180, 180)``).  Canonicalisation of face
+    centres is applied internally.
+
     Args:
         lat: 1-D latitude centres in degrees, shape ``(ny,)``.
         lon: 1-D longitude centres in degrees, shape ``(nx,)``.
+            Must be monotonic.
 
     Returns:
         Compact polygon mesh.
     """
     lat_bounds = _infer_bounds_1d(lat)
-    lon_bounds = _canonical_lon(_infer_bounds_1d(lon))
+    lon_bounds = _infer_bounds_1d(lon)
     ny, nx = lat.size, lon.size
     lon_cov = _lon_coverage_from_centres(lon)
     periodic = lon_cov >= 350.0
@@ -961,9 +966,9 @@ def _regular_grid_mesh(
             lon_cov,
         )
         # For a global grid the last longitude bound coincides with the
-        # first after canonicalisation.  We drop the duplicate column and
-        # let the last column of faces wrap its right-hand nodes back to
-        # column 0 so the mesh is topologically closed.
+        # first (modulo 360°).  We drop the duplicate column and let the
+        # last column of faces wrap its right-hand nodes back to column 0
+        # so the mesh is topologically closed.
         node_idx_full = np.arange((ny + 1) * (nx + 1), dtype=np.int32).reshape(
             ny + 1, nx + 1
         )
@@ -990,9 +995,9 @@ def _regular_grid_mesh(
         node_lon = node_lon_2d.ravel()[keep]
         node_lat = node_lat_2d.ravel()[keep]
     else:
-        node_idx = np.arange(
-            (ny + 1) * (nx + 1), dtype=np.int32
-        ).reshape(ny + 1, nx + 1)
+        node_idx = np.arange((ny + 1) * (nx + 1), dtype=np.int32).reshape(
+            ny + 1, nx + 1
+        )
         face_nodes = np.stack(
             (
                 node_idx[:-1, :-1],
@@ -1223,38 +1228,14 @@ def _source_mesh(
 
     lat, lon = _get_latlon_arrays(ds)
     lat = _normalise_angle_units(lat, source_units)
-    lon = _canonical_lon(_normalise_angle_units(lon, source_units))
+    lon = _normalise_angle_units(lon, source_units)
     y_dim, x_dim = _get_spatial_dims(ds)
 
     if lat.ndim == 1:
         return _regular_grid_mesh(lat, lon), (y_dim, x_dim)
     if lat.ndim == 2:
-        return _curvilinear_grid_mesh(lat, lon), (y_dim, x_dim)
+        return _curvilinear_grid_mesh(lat, _canonical_lon(lon)), (y_dim, x_dim)
     raise ValueError("Latitude/longitude coordinates must be 1-D or 2-D.")
-
-
-def _source_polygons(
-    ds: xr.Dataset,
-    *,
-    source_units: SourceUnits,
-) -> tuple[list[tuple[FloatArray, FloatArray]], tuple[str, ...]]:
-    """Return source polygons as Python tuples.
-
-    Note:
-        Production weight generation uses
-        [`_source_mesh`][grid_doctor.remap_backend._source_mesh] to
-        avoid per-cell Python loops.  This wrapper is kept for
-        compatibility with tests and small-scale debugging.
-
-    Args:
-        ds: Source geometry dataset.
-        source_units: Angular unit convention.
-
-    Returns:
-        ``(polygons, source_dims)``.
-    """
-    mesh, source_dims = _source_mesh(ds, source_units=source_units)
-    return _mesh_to_polygons(mesh), source_dims
 
 
 # ===================================================================

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -951,24 +951,66 @@ def _regular_grid_mesh(
     lat_bounds = _infer_bounds_1d(lat)
     lon_bounds = _canonical_lon(_infer_bounds_1d(lon))
     ny, nx = lat.size, lon.size
+    lon_cov = _lon_coverage_from_centres(lon)
+    periodic = lon_cov >= 350.0
 
-    node_idx = np.arange((ny + 1) * (nx + 1), dtype=np.int32).reshape(ny + 1, nx + 1)
-    face_nodes = np.stack(
-        (
-            node_idx[:-1, :-1],
-            node_idx[:-1, 1:],
-            node_idx[1:, 1:],
-            node_idx[1:, :-1],
-        ),
-        axis=-1,
-    ).reshape(-1, 4)
+    if periodic:
+        logger.debug(
+            "Longitude axis detected as globally periodic (coverage=%.1f°); "
+            "mesh will wrap at the seam.",
+            lon_cov,
+        )
+        # For a global grid the last longitude bound coincides with the
+        # first after canonicalisation.  We drop the duplicate column and
+        # let the last column of faces wrap its right-hand nodes back to
+        # column 0 so the mesh is topologically closed.
+        node_idx_full = np.arange((ny + 1) * (nx + 1), dtype=np.int32).reshape(
+            ny + 1, nx + 1
+        )
+        # Rewrite last column to point to column 0 nodes.
+        node_idx_full[:, -1] = node_idx_full[:, 0]
+        face_nodes = np.stack(
+            (
+                node_idx_full[:-1, :-1],
+                node_idx_full[:-1, 1:],
+                node_idx_full[1:, 1:],
+                node_idx_full[1:, :-1],
+            ),
+            axis=-1,
+        ).reshape(-1, 4)
 
-    node_lon_2d, node_lat_2d = np.meshgrid(lon_bounds, lat_bounds)
+        # Keep only the first nx columns of nodes (drop duplicate last column).
+        keep = np.ones((ny + 1) * (nx + 1), dtype=bool)
+        keep[np.arange(ny + 1) * (nx + 1) + nx] = False
+        old_to_new = np.full((ny + 1) * (nx + 1), -1, dtype=np.int32)
+        old_to_new[keep] = np.arange(keep.sum(), dtype=np.int32)
+        face_nodes = old_to_new[face_nodes]
+
+        node_lon_2d, node_lat_2d = np.meshgrid(lon_bounds, lat_bounds)
+        node_lon = node_lon_2d.ravel()[keep]
+        node_lat = node_lat_2d.ravel()[keep]
+    else:
+        node_idx = np.arange(
+            (ny + 1) * (nx + 1), dtype=np.int32
+        ).reshape(ny + 1, nx + 1)
+        face_nodes = np.stack(
+            (
+                node_idx[:-1, :-1],
+                node_idx[:-1, 1:],
+                node_idx[1:, 1:],
+                node_idx[1:, :-1],
+            ),
+            axis=-1,
+        ).reshape(-1, 4)
+        node_lon_2d, node_lat_2d = np.meshgrid(lon_bounds, lat_bounds)
+        node_lon = node_lon_2d.ravel()
+        node_lat = node_lat_2d.ravel()
+
     face_lon_2d, face_lat_2d = np.meshgrid(_canonical_lon(lon), lat)
 
     return PolygonMesh(
-        node_lon=node_lon_2d.ravel().astype(np.float64, copy=False),
-        node_lat=node_lat_2d.ravel().astype(np.float64, copy=False),
+        node_lon=node_lon.astype(np.float64, copy=False),
+        node_lat=node_lat.astype(np.float64, copy=False),
         face_nodes=face_nodes,
         face_lon=face_lon_2d.ravel().astype(np.float64, copy=False),
         face_lat=face_lat_2d.ravel().astype(np.float64, copy=False),

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -29,7 +29,7 @@ from grid_doctor.remap_backend import (
     _infer_curvilinear_corners,
     _looks_global,
     _normalise_angle_units,
-    _source_polygons,
+    _regular_grid_mesh,
 )
 from .helpers import _FakeHealpixModule
 
@@ -78,37 +78,76 @@ class TestPrimitiveHelpers:
 
 
 # ===================================================================
-# Source polygons
+# Regular grid mesh (antimeridian & periodicity)
 # ===================================================================
 
 
-class TestSourcePolygons:
-    def test_regular_grid_polygons(self, regular_ds: xr.Dataset) -> None:
-        polygons, dims = _source_polygons(regular_ds, source_units="auto")
-        assert dims == ("y", "x")
-        n_expected = regular_ds.sizes["y"] * regular_ds.sizes["x"]
-        assert len(polygons) == n_expected
-        assert len(polygons[0][0]) == 4
+class TestRegularGridMesh:
+    """Tests for the longitude unwrapping and periodic node wrapping."""
 
-    def test_curvilinear_grid_polygons(self, curvilinear_ds: xr.Dataset) -> None:
-        polygons, dims = _source_polygons(curvilinear_ds, source_units="auto")
-        assert dims == ("y", "x")
-        n_expected = curvilinear_ds.sizes["y"] * curvilinear_ds.sizes["x"]
-        assert len(polygons) == n_expected
+    def test_global_grid_no_giant_polygon(self) -> None:
+        """All source polygons must be ≈ dlon wide, not ~180°."""
+        lat = np.linspace(-90.0, 90.0, 8)
+        lon = np.linspace(0.125, 359.875, 16)
+        mesh = _regular_grid_mesh(lat, lon)
+        # Gather corner longitudes for every face: shape (n_face, 4).
+        corner_lons = mesh.node_lon[mesh.face_nodes]
+        # Unwrap per-face to handle the ±180 wraparound.
+        deltas = np.diff(corner_lons, axis=1)
+        deltas = (deltas + 180.0) % 360.0 - 180.0
+        unwrapped = np.concatenate(
+            [corner_lons[:, :1], corner_lons[:, :1] + np.cumsum(deltas, axis=1)],
+            axis=1,
+        )
+        spans = unwrapped.max(axis=1) - unwrapped.min(axis=1)
+        dlon = 360.0 / lon.size
+        worst = int(np.argmax(spans))
+        assert spans.max() < 2.0 * dlon, (
+            f"Face {worst} spans {spans[worst]:.1f}° in longitude"
+        )
 
-    def test_unstructured_grid_polygons_convert_radians(
-        self, unstructured_rad_ds: xr.Dataset
-    ) -> None:
-        polygons, dims = _source_polygons(unstructured_rad_ds, source_units="auto")
-        assert dims == ("cell",)
-        first_lon, first_lat = polygons[0]
-        assert np.nanmax(np.abs(first_lon)) > 0.1
-        assert np.nanmax(np.abs(first_lat)) > 0.1
+    def test_global_grid_node_count_excludes_duplicate_column(self) -> None:
+        """Periodic grids should have (ny+1)*nx nodes, not (ny+1)*(nx+1)."""
+        lat = np.linspace(-90.0, 90.0, 12)
+        lon = np.linspace(0.0, 360.0, 24, endpoint=False)
+        mesh = _regular_grid_mesh(lat, lon)
+        ny, nx = lat.size, lon.size
+        assert mesh.node_lon.size == (ny + 1) * nx
 
-    def test_unstructured_requires_vertices(self, unstructured_ds: xr.Dataset) -> None:
-        ds = unstructured_ds.drop_vars(["clon_vertices", "clat_vertices"])
-        with pytest.raises(ValueError, match="require per-cell vertex"):
-            _source_polygons(ds, source_units="auto")
+    def test_global_grid_last_face_wraps(self) -> None:
+        """The last face in each lat row should reference column-0 nodes."""
+        lat = np.linspace(-90.0, 90.0, 4)
+        lon = np.linspace(0.0, 360.0, 8, endpoint=False)
+        mesh = _regular_grid_mesh(lat, lon)
+        nx = lon.size
+        # Last face of the first lat row: face index nx-1.
+        last_face = mesh.face_nodes[nx - 1]
+        # The right-hand nodes (indices 1 and 2) should be in column 0,
+        # i.e. node indices 0 and nx (first column, rows 0 and 1).
+        assert last_face[1] == 0  # top-right wraps to column 0
+        assert last_face[2] == nx  # bottom-right wraps to column 0
+
+    def test_regional_grid_no_wrapping(self) -> None:
+        """A regional grid must not have periodic wrapping."""
+        lat = np.linspace(20.0, 40.0, 5)
+        lon = np.linspace(10.0, 30.0, 6)
+        mesh = _regular_grid_mesh(lat, lon)
+        ny, nx = lat.size, lon.size
+        # Non-periodic: (ny+1)*(nx+1) nodes.
+        assert mesh.node_lon.size == (ny + 1) * (nx + 1)
+
+    def test_antimeridian_bounds_are_monotonic(self) -> None:
+        """Node longitudes across the antimeridian must stay monotonic."""
+        lat = np.linspace(-90.0, 90.0, 4)
+        lon = np.linspace(0.125, 359.875, 8)
+        mesh = _regular_grid_mesh(lat, lon)
+        # Extract the first row of node longitudes (ny+1 rows of nx nodes).
+        nx = lon.size
+        first_row_lons = mesh.node_lon[:nx]
+        # The sequence must be monotonically increasing.
+        assert np.all(np.diff(first_row_lons) > 0), (
+            f"Node longitudes are not monotonic: {first_row_lons}"
+        )
 
 
 # ===================================================================


### PR DESCRIPTION
This PR removes an artifact that was introduced by calculating lon-bounds for regular grids based on canonical lons [-180, 180). Some lon vectors might have not been monotonic after canonicalization anymore. Which would  have lead to huge jumps when calculating their bounds. As a consequence the weight matrix for those "jump" places would take into account half the globe for conservative regridding. Which lead to bogus results.

This fixes this @mannreis .  I also introduces a small lon wrapping for periodical grids where the 1st and last lon bounds coincide. Here wrap the bounds to avoid artifacts. But it might well be that ESMF can handle those cases - I left it there just in case.