### PR TITLE
Add simple icon-dream mode.

### DIFF
--- a/scripts/icon-dream/README.md
+++ b/scripts/icon-dream/README.md
@@ -5,7 +5,22 @@
 Icon dream is a reanalysis product from the German Weather Service.
 
 
+
 ## How to run:
+
+There are two main modes:
+
+1. the "normal" slurm mode that uses [`reflow`](https://www.reflow.docs.org)
+ to split the remap jobs into smaller chunks that can be handled within the
+ maximum wall time of 8 hours. The file `convert.py` hosts the "slurm" mode.
+1. the "simple" mode doesn't split the tasks into smaller chunks. It calculates
+   the HEALPix pyramid using the `cupy` backend and pushes the results directly
+   to S3. This mode is not slurm "friendly" but can be directly and easily
+   applied on servers without resource restrictions such as the DRKZ
+   Grace-Hopper nodes. The file `convert_gh.py` hosts the "simple" mode.
+
+
+Follow these steps to apply the *slurm mode*:
 
 1. Create and download your s3-secrets file from [https://eu-dkrz-3.dkrz.cloud/access-keys](https://eu-dkrz-3.dkrz.cloud/access-keys)
 2. Put the secrets files somewhere into your home on levante.
@@ -92,6 +107,32 @@ to check the job status or
 ```console
 python convert.py runs
 python convert.py status <run-id>
+```
+
+To apply the *simple mode* use the `convert_gh.py` script:
+
+```console
+python convert_gh.py --help
+Usage: convert-icon-dream [-h] --s3-bucket S3_BUCKET [--s3-endpoint S3_ENDPOINT] [--s3-credentials-file S3_CREDENTIALS_FILE] [-v] [--variables VARIABLES [VARIABLES ...]]
+                          [--freq FREQ] [--run-dir RUN_DIR] [--override]
+
+Convert ICON-DREAM
+
+Options:
+  -h, --help            show this help message and exit
+  --s3-bucket S3_BUCKET
+                        S3 target bucket. (default: None)
+  --s3-endpoint S3_ENDPOINT
+                        S3 endpoint URL. (default: https://s3.eu-dkrz-3.dkrz.cloud)
+  --s3-credentials-file S3_CREDENTIALS_FILE
+                        Path to a JSON file with accessKey/secretKey. (default: /home/wilfred/.s3-credentials.json)
+  -v, --verbose         Increase verbosity with repeated flags such as -v or -vv. (default: 0)
+  --variables VARIABLES [VARIABLES ...]
+                        Variables to process (default: ['t_2m', 'tot_prec'])
+  --freq, -f FREQ       ICON-DREAM data frequency (default: hourly)
+  --run-dir RUN_DIR     The run directory (default: /scratch/w/wilfred/grid-doctor/icon-dream/)
+  --override, -o        Override existing files. (default: False)
+
 ```
 
 > [!IMPORTANT]

--- a/scripts/icon-dream/convert_gh.py
+++ b/scripts/icon-dream/convert_gh.py
@@ -1,0 +1,187 @@
+"""Run the conversion on a single GH node."""
+
+import logging
+from getpass import getuser
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import xarray as xr
+from icon_dream_reflow_helpers.common import target_root
+
+import grid_doctor as gd
+import grid_doctor.cli as gd_cli
+
+if TYPE_CHECKING:
+    import argparse
+
+SCRATCH_DIR = "/scratch/{u[0]}/{u}/grid-doctor/icon-dream/".format(u=getuser())
+
+
+logger = logging.getLogger("icon-dream2healpix")
+
+
+def download_files(
+    s3_options: dict[str, str],
+    variables: list[str] | None = None,
+    frequency: str = "hourly",
+    s3_bucket: str = "icon-dream",
+    override: bool = False,
+    run_dir: Path = Path(SCRATCH_DIR),
+) -> list[dict[str, str]]:
+    """Download files."""
+
+    from icon_dream_reflow_helpers.planning import (IconDreamSource,
+                                                    load_existing_target_info,
+                                                    parse_datetime)
+
+    variables = variables or ["t_2m", "tot_prec"]
+    src = IconDreamSource(variables, frequency, ("2010-01-01T00:00", "now"))
+    if override is False:
+        existing = load_existing_target_info(
+            target_root(s3_bucket, frequency), s3_options
+        )
+        existing_max = (
+            parse_datetime(existing["max_time"]) if existing["max_time"] else None
+        )
+    else:
+        existing_max = None
+    items = src.list_items(
+        existing_max_time=existing_max, existing_variables=set(variables)
+    )
+    for item in items:
+        tmp_path = run_dir / "raw-input" / item["variable"] / item["filename"]
+        if not tmp_path.is_file():
+            logger.info("Downloading %s to %s", item["url"], tmp_path)
+            gd_cli.download_file(item["url"], tmp_path.parent)
+        else:
+            logger.debug("Skipping existing file %s", tmp_path)
+        item["raw-path"] = str(tmp_path)
+    return items
+
+
+def remap(
+    items: list[dict[str, str]],
+    s3_options: dict[str, str],
+    run_dir: Path = Path(SCRATCH_DIR),
+) -> None:
+    """Remap the items."""
+
+    from icon_dream_reflow_helpers.common import (DEFAULT_GRID_URL,
+                                                  chunk_for_target_store_size)
+    from icon_dream_reflow_helpers.transform import \
+        prepare_dataset_for_regridding
+
+    variables: dict[str, list[Path]] = {}
+    dsets: list[xr.Dataset] = []
+    logger.debug("Opening grid")
+    grid_ds = xr.open_dataset(
+        gd_cli.download_file(DEFAULT_GRID_URL, run_dir / "shared")
+    )
+    logger.debug("Calculating max healpix level .... ")
+    max_level = gd.resolution_to_healpix_level(gd.get_latlon_resolution(grid_ds))
+    logger.debug("Calculating max healpix level .... %d", max_level)
+    logger.debug("Creating weight matrix ...")
+    weight_file = gd.cached_weights(
+        grid_ds,
+        level=max_level,
+        prefer_offline=True,
+        nproc=48,
+        cache_path="/work/ks1387/healpix-weights",
+    )
+    logger.debug("Creating weight matrix ... %s ", weight_file)
+    for item in items:
+        variables.setdefault(item["variable"], [])
+        variables[item["variable"]].append(Path(item["raw-path"]))
+
+    for var, files in variables.items():
+        logger.debug("Reading %d input files for variable %s", len(files), var)
+        ds = xr.open_mfdataset(
+            sorted(files),
+            combine="nested",
+            concat_dim="time",
+            parallel=True,
+            data_vars="minimal",
+            coords="minimal",
+            compat="override",
+            chunks="auto",
+            join="override",  # only if non-time dims really match
+            combine_attrs="override",
+        )
+        logger.debug("Preprocessing files ... ")
+        dsets.append(
+            prepare_dataset_for_regridding(ds).drop_duplicates(dim="time", keep="first")
+        )
+        logger.debug("Preprocessing files .... done")
+    dset = xr.merge(dsets, join="outer").chunk({"cell": -1})
+    chunk = chunk_for_target_store_size(level=max_level)
+    logger.debug("Creating healpix pyramid ... ")
+    pyramid = gd.create_healpix_pyramid(
+        dset, max_level=max_level, weights_path=weight_file, backend="cupy"
+    )
+    logger.debug("Rechunking ...")
+    for key in pyramid:
+        pyramid[key] = pyramid[key].chunk(chunk)
+    return pyramid
+
+
+def upload_pyramid(
+    pyramid: dict[int, xr.Dataset], s3_options: dict[str, str], s3_path: str
+) -> None:
+    """Upload the healpix pyramid."""
+
+    logger.debug("Uploading healpix pyramid to %s", s3_path)
+    gd.save_pyramid_to_s3(
+        pyramid,
+        s3_path,
+        s3_options,
+        mode="w",
+        compute=True,
+        zarr_format=2,
+    )
+
+
+def cli(argv: list[str] | None = None) -> "argparse.Namespace":
+    """Setup the cli."""
+
+    parser = gd_cli.get_parser("convert-icon-dream", description="Convert ICON-DREAM")
+    parser.add_argument(
+        "--variables",
+        default=["t_2m", "tot_prec"],
+        nargs="+",
+        help="Variables to process",
+    )
+    parser.add_argument(
+        "--freq", "-f", default="hourly", help="ICON-DREAM data frequency"
+    )
+    parser.add_argument(
+        "--run-dir", type=Path, help="The run directory", default=SCRATCH_DIR
+    )
+    parser.add_argument(
+        "--override", "-o", action="store_true", help="Override existing files."
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = cli()
+    gd_cli.setup_logging_from_args(args)
+    s3_options = gd.get_s3_options(
+        args.s3_endpoint, args.s3_credentials_file.expanduser()
+    )
+    logger.info("Working with s3_options: %s", s3_options)
+    s3_path = target_root(f"s3://{args.s3_bucket}", args.freq)
+    raw_files = download_files(
+        s3_options,
+        args.variables,
+        args.freq,
+        s3_bucket=args.s3_bucket,
+        override=args.override,
+        run_dir=args.run_dir,
+    )
+    pyramid = remap(
+        raw_files,
+        s3_options,
+        run_dir=args.run_dir,
+    )
+
+    upload_pyramid(pyramid, s3_options, s3_path)

--- a/scripts/icon-dream/icon_dream_reflow_helpers/common.py
+++ b/scripts/icon-dream/icon_dream_reflow_helpers/common.py
@@ -103,7 +103,7 @@ def build_paths(run_dir: str | Path) -> dict[str, Path]:
         "run_dir": root,
         "plan_path": root / "plan.json",
         "grid_path": root / "shared" / "ICON-DREAM-Global_grid.nc",
-        "weights_path": root / "shared" / "healpix-weights.nc",
+        "weights_path": Path("/work/ks1387/healpix-weights"),
         "temp_root": root / "temp-healpix",
         "raw_root": root / "raw-input",
     }
@@ -256,7 +256,7 @@ def open_existing_target(
 
 def target_root(bucket: str, frequency: str) -> str:
     """Return the S3 root for a given bucket and frequency."""
-    return f"{bucket.rstrip('/')}/healpix/icon-dream-global/{frequency}"
+    return f"{bucket.rstrip('/')}/healpix/reanalysis/icon-dream-global/icon/{frequency}"
 
 
 def load_existing_target_info(

--- a/scripts/icon-dream/icon_dream_reflow_helpers/planning.py
+++ b/scripts/icon-dream/icon_dream_reflow_helpers/planning.py
@@ -238,14 +238,16 @@ def prepare_shared_assets(
         if max_level is None
         else int(max_level)
     )
-    gd.cached_weights(grid_ds, level=resolved_level, cache_path=paths["weights_path"])
+    weight_file = gd.cached_weights(
+        grid_ds, level=resolved_level, cache_path=paths["weights_path"]
+    )
     plan.update(
         grid_path=str(downloaded_grid),
-        weights_path=str(paths["weights_path"]),
+        weights_path=str(weight_file),
         max_level=resolved_level,
     )
     save_plan(plan, paths["plan_path"])
-    return str(paths["weights_path"])
+    return str(weight_file)
 
 
 def download_source_item(

--- a/scripts/icon-dream/icon_dream_reflow_helpers/publish.py
+++ b/scripts/icon-dream/icon_dream_reflow_helpers/publish.py
@@ -263,18 +263,20 @@ def finalize_outputs(
 
     level = worker_results["level"]
     chunks = chunk_for_target_store_size(level=level)
+    print(f"Working on {worker_results['level_paths']}")
     candidate = xr.open_mfdataset(
-        worker_results["level_paths"],
+        sorted(worker_results["level_paths"]),
         preprocess=drop_surface_coords,
         combine="nested",
         concat_dim="time",
         chunks=chunks,
-        parallel=True,
+        parallel=False,
         data_vars="minimal",
         coords="minimal",
         compat="override",
         join="override",  # only if non-time dims really match
         combine_attrs="override",
+        engine="h5netcdf",
     ).sortby("time")
     candidate = candidate.drop_duplicates(dim="time", keep="first")
     return merge_level_dataset(

--- a/scripts/icon-dream/icon_dream_reflow_helpers/transform.py
+++ b/scripts/icon-dream/icon_dream_reflow_helpers/transform.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Sequence
 
@@ -11,8 +10,9 @@ import numpy as np
 
 import grid_doctor as gd
 
-from .common import (build_paths, load_plan, maybe_start_local_client,
-                     open_source_dataset, to_time_strings)
+from .common import (build_paths, drop_surface_coords, load_plan,
+                     maybe_start_local_client, open_source_dataset,
+                     to_time_strings)
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -37,7 +37,7 @@ def flatten_forecast_time(ds: "xr.Dataset") -> "xr.Dataset":
         return ds
     if ds.sizes.get("step", 1) == 1:
         ds = ds.isel(step=0, drop=True)
-    return ds.load()
+    return ds
 
 
 def normalise_time_axis(ds: "xr.Dataset") -> "xr.Dataset":
@@ -58,7 +58,9 @@ def normalise_time_axis(ds: "xr.Dataset") -> "xr.Dataset":
 
 def prepare_dataset_for_regridding(ds: "xr.Dataset") -> "xr.Dataset":
     """Apply the minimal normalisation needed for regridding."""
-    return normalise_time_axis(rename_values_dim(ds)).rename({"values": "cell"})
+    return drop_surface_coords(
+        normalise_time_axis(rename_values_dim(ds)).rename({"values": "cell"})
+    )
 
 
 def chunk_healpix_dataset(
@@ -97,7 +99,7 @@ def write_temp_pyramid(
     for level, level_ds in pyramid.items():
         target = level_output_path(output_root, level).with_suffix(".nc")
         if target.exists():
-            shutil.rmtree(target)
+            target.unlink()
         chunked = chunk_healpix_dataset(
             level_ds, time_chunk=time_chunk, cell_chunk=cell_chunk
         )


### PR DESCRIPTION
Remapping can take a long time. We can either split the jobs to make them fit into a slurm job walltime at dkrz or just apply them straight away. Straight away application simply follows the "normal" grid-doctor approach. Lazily compute the healpix pyramid and push the results to s3. 

This might take a long time - essentially the push to s3 takes the most time. But if applied on a special node such as one of the Grace-Hopper nodes that supports GPU application without any wall time limit we are fine. 

The PR adds a script to add a simple remap strategy on such nodes where walll time is not limited.  