### PR TITLE
allow save_pyramid to write to local disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pyramid = gd.create_healpix_pyramid(
     weights_path=weights_dir,
     max_level=max_level
 )
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     "s3://my-bucket/dataset.zarr",
     s3_options=gd.get_s3_options(
@@ -112,7 +112,7 @@ gd_cli.setup_logging_from_args(args)
 
 ds = gd.cached_open_dataset(["path/to/*.nc"])
 pyramid = gd.create_healpix_pyramid(ds)
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     chunked,
     f"s3://{args.s3_bucket}/my-dataset.zarr",
     s3_options=gd.get_s3_options(args.s3_endpoint, args.s3_credentials_file),

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -9,7 +9,7 @@ efficient IO and scalable data layout decisions.
 Once a pyramid has been created, it can be written to object storage for
 cloud-native access and downstream analysis.
 
-::: grid_doctor.save_pyramid_to_s3
+::: grid_doctor.save_pyramid
     options:
       show_root_heading: true
       show_root_full_path: false

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ gd_cli.setup_logging_from_args(args)
 ds = gd.cached_open_dataset(["path/to/*.nc"])
 weights_file = gd.cached_weights("~/weights/", nproc=4)
 pyramid = gd.create_healpix_pyramid(ds, weights_path=weights_path)
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     f"s3://{args.s3_bucket}/my-dataset.zarr",
     s3_options=gd.get_s3_options(args.s3_endpoint, args.s3_credentials_file),
@@ -60,11 +60,11 @@ gd.save_pyramid_to_s3(
     Always read secrets from environment variables or a credentials file.
 
 !!! tip "Writing to local disk"
-    `save_pyramid_to_s3` also writes to local disk. Pass a plain directory
+    `save_pyramid` also writes to local disk. Pass a plain directory
     path (no `s3://` scheme) and omit `s3_options`:
 
 ```python
-    gd.save_pyramid_to_s3(pyramid, "/work/ks1387", mode="w")
+    gd.save_pyramid(pyramid, "/work/ks1387", mode="w")
 ```
 
     The same `level_<n>.zarr` layout is written under that directory.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,6 +59,15 @@ gd.save_pyramid_to_s3(
 !!! warning "Do not commit S3 credentials"
     Always read secrets from environment variables or a credentials file.
 
+!!! tip "Writing to local disk"
+    `save_pyramid_to_s3` also writes to local disk. Pass a plain directory
+    path (no `s3://` scheme) and omit `s3_options`:
+
+```python
+    gd.save_pyramid_to_s3(pyramid, "/work/ks1387", mode="w")
+```
+
+    The same `level_<n>.zarr` layout is written under that directory.
 ## Logging / Verbosity
 
 Every script that uses `gd_cli.get_parser` automatically gets a `-v` flag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ import grid_doctor as gd
 ds = gd.cached_open_dataset(["data/*.nc"])
 weights_file = gd.cached_weights("/path/to/weights/", nproc=4)
 pyramid = gd.create_healpix_pyramid(ds, weights_path=weights_file)
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     "s3://my-bucket/era5",
     s3_options=gd.get_s3_options(

--- a/docs/recipes/icon.md
+++ b/docs/recipes/icon.md
@@ -45,7 +45,7 @@ pyramid = gd.create_healpix_pyramid(
     ds, max_level=max_level, weights_path=weights_file,
 )
 
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     "s3://my-bucket/healpix/icon-dream/hourly",
     s3_options=gd.get_s3_options(

--- a/docs/recipes/structured.md
+++ b/docs/recipes/structured.md
@@ -29,7 +29,7 @@ weights_file = gd.cached_weights(
 pyramid = gd.create_healpix_pyramid(ds)
 
 # 3. Upload
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     "s3://my-bucket/era5/2t",
     s3_options=gd.get_s3_options(
@@ -78,7 +78,7 @@ weights_file = gd.cached_weights(
     prefer_offline=True
 )
 pyramid = gd.create_healpix_pyramid(ds)
-gd.save_pyramid_to_s3(
+gd.save_pyramid(
     pyramid,
     f"s3://{args.s3_bucket}/era5",
     s3_options=gd.get_s3_options(args.s3_endpoint, args.s3_credentials_file),

--- a/docs/waterpark.md
+++ b/docs/waterpark.md
@@ -127,7 +127,7 @@ nanmean), not by repeated remapping.
         "https://s3-example.org",
         Path("~/.s3-credentials.json").expanduser(),
     )
-    %time gd.save_pyramid_to_s3(
+    %time gd.save_pyramid(
         pyramid,
         "/icon-dream/healpix/icdc/modis/aqua",
         s3_options,

--- a/scripts/era5/convert.py
+++ b/scripts/era5/convert.py
@@ -11,7 +11,7 @@ from os import getenv
 
 from grid_doctor import (
     cached_open_dataset,
-    save_pyramid_to_s3,
+    save_pyramid,
     latlon_to_healpix_pyramid,
 )
 
@@ -101,7 +101,7 @@ def convert(init=False, region={"time": slice(0, 96)}):
 
         if init:
             logging.info("Initializing store %s", dst_url)
-            save_pyramid_to_s3(ds_hp, dst_url, mode="w", compute=False, s3_options=opts)
+            save_pyramid(ds_hp, dst_url, mode="w", compute=False, s3_options=opts)
 
         else:
             region = {
@@ -110,7 +110,7 @@ def convert(init=False, region={"time": slice(0, 96)}):
             }
 
             logging.info("Writting to existing store on region: %s", str(region))
-            save_pyramid_to_s3(
+            save_pyramid(
                 ds_hp, dst_url, mode="r+", region=region, s3_options=opts
             )
 

--- a/src/grid_doctor/__init__.py
+++ b/src/grid_doctor/__init__.py
@@ -34,7 +34,7 @@ _ATTRS: dict[str, str] = {
     "regrid_to_healpix": ".remap",
     "regrid_unstructured_to_healpix": ".remap",
     "resolution_to_healpix_level": ".helpers",
-    "save_pyramid_to_s3": ".helpers",
+    "save_pyramid": ".helpers",
     "setup_logging": ".log",
 }
 
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
         get_latlon_resolution,
         latlon_to_healpix_pyramid,
         resolution_to_healpix_level,
-        save_pyramid_to_s3,
+        save_pyramid,
     )
     from .log import setup_logging
     from .remap import (
@@ -104,6 +104,6 @@ __all__ = [
     "regrid_to_healpix",
     "regrid_unstructured_to_healpix",
     "resolution_to_healpix_level",
-    "save_pyramid_to_s3",
+    "save_pyramid",
     "setup_logging",
 ]

--- a/src/grid_doctor/__init__.pyi
+++ b/src/grid_doctor/__init__.pyi
@@ -7,7 +7,7 @@ from .helpers import create_healpix_pyramid as create_healpix_pyramid
 from .helpers import get_latlon_resolution as get_latlon_resolution
 from .helpers import latlon_to_healpix_pyramid as latlon_to_healpix_pyramid
 from .helpers import resolution_to_healpix_level as resolution_to_healpix_level
-from .helpers import save_pyramid_to_s3 as save_pyramid_to_s3
+from .helpers import save_pyramid as save_pyramid
 from .log import setup_logging as setup_logging
 from .remap import apply_weight_file as apply_weight_file
 from .remap import compute_healpix_weights as compute_healpix_weights

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -445,7 +445,7 @@ def create_healpix_pyramid(
 # ===================================================================
 
 
-def save_pyramid_to_s3(
+def save_pyramid(
     pyramid: dict[int, xr.Dataset],
     s3_path: str,
     s3_options: dict[str, Any] | None = None,
@@ -577,5 +577,5 @@ __all__ = [
     "regrid_to_healpix",
     "regrid_unstructured_to_healpix",
     "resolution_to_healpix_level",
-    "save_pyramid_to_s3",
+    "save_pyramid",
 ]

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -447,7 +447,7 @@ def create_healpix_pyramid(
 
 def save_pyramid(
     pyramid: dict[int, xr.Dataset],
-    s3_path: str,
+    path: str,
     s3_options: dict[str, Any] | None = None,
     *,
     mode: Literal["a", "w", "r+"] = "a",
@@ -458,13 +458,13 @@ def save_pyramid(
 ) -> None:
     """Write a HEALPix pyramid to Zarr stores on S3 or local disk.
 
-    Each level is stored below ``"<s3_path>/level_<level>.zarr"``.
+    Each level is stored below ``"<path>/level_<level>.zarr"``.
 
     Parameters
     ----------
     pyramid:
         Mapping of HEALPix level to dataset.
-    s3_path:
+    path:
         Target prefix.  An ``"s3://bucket/pyramid"`` URL writes to S3; any
         other value is treated as a local directory path.
     s3_options:
@@ -481,10 +481,10 @@ def save_pyramid(
     encoding:
         Per-level encoding dictionaries.
     """
-    is_s3 = s3_path.startswith("s3://")
+    is_s3 = path.startswith("s3://")
     fs = s3fs.S3FileSystem(**(s3_options or {})) if is_s3 else None
     for level, dataset in pyramid.items():
-        level_path = f"{s3_path}/level_{level}.zarr"
+        level_path = f"{path}/level_{level}.zarr"
         logger.info("Writing HEALPix level %s to %s", level, level_path)
         store: Any
         if is_s3:

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -13,6 +13,7 @@ Remapping itself lives in [`grid_doctor.remap`][grid_doctor.remap].
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import numpy as np
@@ -447,7 +448,7 @@ def create_healpix_pyramid(
 def save_pyramid_to_s3(
     pyramid: dict[int, xr.Dataset],
     s3_path: str,
-    s3_options: dict[str, Any],
+    s3_options: dict[str, Any] | None = None,
     *,
     mode: Literal["a", "w", "r+"] = "a",
     compute: bool = True,
@@ -455,7 +456,7 @@ def save_pyramid_to_s3(
     zarr_format: Literal[2, 3] = 2,
     encoding: dict[int, dict[str, dict[str, Any]]] | None = None,
 ) -> None:
-    """Write a HEALPix pyramid to S3-backed Zarr stores.
+    """Write a HEALPix pyramid to Zarr stores on S3 or local disk.
 
     Each level is stored below ``"<s3_path>/level_<level>.zarr"``.
 
@@ -464,9 +465,11 @@ def save_pyramid_to_s3(
     pyramid:
         Mapping of HEALPix level to dataset.
     s3_path:
-        S3 prefix such as ``"s3://bucket/pyramid"``.
+        Target prefix.  An ``"s3://bucket/pyramid"`` URL writes to S3; any
+        other value is treated as a local directory path.
     s3_options:
-        Options forwarded to :class:`s3fs.S3FileSystem`.
+        Options forwarded to :class:`s3fs.S3FileSystem`.  Only used for S3
+        targets; ignored (and optional) for local paths.
     mode:
         Zarr write mode.
     compute:
@@ -478,11 +481,17 @@ def save_pyramid_to_s3(
     encoding:
         Per-level encoding dictionaries.
     """
-    fs = s3fs.S3FileSystem(**s3_options)
+    is_s3 = s3_path.startswith("s3://")
+    fs = s3fs.S3FileSystem(**(s3_options or {})) if is_s3 else None
     for level, dataset in pyramid.items():
         level_path = f"{s3_path}/level_{level}.zarr"
         logger.info("Writing HEALPix level %s to %s", level, level_path)
-        store = s3fs.S3Map(root=level_path, s3=fs)
+        store: Any
+        if is_s3:
+            store = s3fs.S3Map(root=level_path, s3=fs)
+        else:
+            Path(level_path).parent.mkdir(parents=True, exist_ok=True)
+            store = level_path
         zarr_options = ZarrOptions(compute=compute, mode=mode, zarr_format=zarr_format)
         if zarr_format == 2:
             zarr_options["consolidated"] = True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -21,7 +21,7 @@ from grid_doctor.helpers import (
     get_latlon_resolution,
     latlon_to_healpix_pyramid,
     resolution_to_healpix_level,
-    save_pyramid_to_s3,
+    save_pyramid,
 )
 
 
@@ -461,7 +461,7 @@ class TestSavePyramidToS3:
         pyramid = self._make_pyramid()
         mock_s3map.return_value = mock.MagicMock()
         with mock.patch.object(xr.Dataset, "to_zarr") as mock_zarr:
-            save_pyramid_to_s3(pyramid, "s3://bucket/test", s3_options={}, mode="w")
+            save_pyramid(pyramid, "s3://bucket/test", s3_options={}, mode="w")
             assert mock_zarr.call_count == 2
 
     @mock.patch("grid_doctor.helpers.s3fs.S3FileSystem")
@@ -473,7 +473,7 @@ class TestSavePyramidToS3:
         pyramid = self._make_pyramid()
         mock_s3map.return_value = mock.MagicMock()
         with mock.patch.object(xr.Dataset, "to_zarr") as mock_zarr:
-            save_pyramid_to_s3(
+            save_pyramid(
                 pyramid, "s3://bucket/test", s3_options={}, zarr_format=3
             )
             for call in mock_zarr.call_args_list:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -40,7 +40,7 @@ class TestPublicCallables:
             "regrid_to_healpix",
             "regrid_unstructured_to_healpix",
             "resolution_to_healpix_level",
-            "save_pyramid_to_s3",
+            "save_pyramid",
             "setup_logging",
         ],
     )

--- a/tests/test_s3_and_cli.py
+++ b/tests/test_s3_and_cli.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from grid_doctor.cli.parser import get_parser, setup_logging_from_args
 from grid_doctor.cli.script_utils import AutoRaiseSession, get_scratch
-from grid_doctor.helpers import save_pyramid_to_s3
+from grid_doctor.helpers import save_pyramid
 
 
 def _tiny_pyramid() -> dict[int, xr.Dataset]:
@@ -81,14 +81,14 @@ class TestSavePyramidToS3Local:
     def test_writes_levels_to_disk(self, tmp_path: Path) -> None:
         pyramid = _tiny_pyramid()
         out = tmp_path / "pyramid"
-        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        save_pyramid(pyramid, str(out), mode="w")
         for level in pyramid:
             assert (out / f"level_{level}.zarr").is_dir()
 
     def test_round_trips_values(self, tmp_path: Path) -> None:
         pyramid = _tiny_pyramid()
         out = tmp_path / "pyramid"
-        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        save_pyramid(pyramid, str(out), mode="w")
         for level, dataset in pyramid.items():
             reloaded = xr.open_zarr(out / f"level_{level}.zarr")
             xr.testing.assert_allclose(reloaded[["tas"]], dataset[["tas"]])
@@ -96,7 +96,7 @@ class TestSavePyramidToS3Local:
     def test_creates_missing_parent_directories(self, tmp_path: Path) -> None:
         pyramid = _tiny_pyramid()
         out = tmp_path / "nested" / "deeper" / "pyramid"
-        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        save_pyramid(pyramid, str(out), mode="w")
         assert (out / "level_0.zarr").is_dir()
 
     def test_s3_options_optional_for_local(self, tmp_path: Path) -> None:
@@ -104,7 +104,7 @@ class TestSavePyramidToS3Local:
         # not construct an S3 client.
         out = tmp_path / "pyramid"
         with mock.patch("grid_doctor.helpers.s3fs.S3FileSystem") as fs:
-            save_pyramid_to_s3(_tiny_pyramid(), str(out), mode="w")
+            save_pyramid(_tiny_pyramid(), str(out), mode="w")
         fs.assert_not_called()
 
 
@@ -123,7 +123,7 @@ class TestSavePyramidToS3Remote:
                 "grid_doctor.helpers.s3fs.S3Map", return_value="s3-store"
             ) as s3_map,
         ):
-            save_pyramid_to_s3(
+            save_pyramid(
                 {0: dataset},  # type: ignore[dict-item]
                 "s3://bucket/pyr",
                 {"key": "x", "secret": "y"},

--- a/tests/test_s3_and_cli.py
+++ b/tests/test_s3_and_cli.py
@@ -12,6 +12,19 @@ import xarray as xr
 
 from grid_doctor.cli.parser import get_parser, setup_logging_from_args
 from grid_doctor.cli.script_utils import AutoRaiseSession, get_scratch
+from grid_doctor.helpers import save_pyramid_to_s3
+
+
+def _tiny_pyramid() -> dict[int, xr.Dataset]:
+    """a two-level HEALPix-like pyramid for write tests."""
+
+    def level_ds(npix: int) -> xr.Dataset:
+        return xr.Dataset(
+            {"tas": ("cell", np.arange(npix, dtype="float32"))},
+            coords={"cell": np.arange(npix)},
+        )
+
+    return {0: level_ds(12), 1: level_ds(48)}
 
 
 class TestGetParser:
@@ -62,3 +75,61 @@ class TestAutoRaiseSession:
         session = AutoRaiseSession()
         with pytest.raises(Exception, match="404"):
             session.get("http://example.com")
+
+
+class TestSavePyramidToS3Local:
+    def test_writes_levels_to_disk(self, tmp_path: Path) -> None:
+        pyramid = _tiny_pyramid()
+        out = tmp_path / "pyramid"
+        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        for level in pyramid:
+            assert (out / f"level_{level}.zarr").is_dir()
+
+    def test_round_trips_values(self, tmp_path: Path) -> None:
+        pyramid = _tiny_pyramid()
+        out = tmp_path / "pyramid"
+        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        for level, dataset in pyramid.items():
+            reloaded = xr.open_zarr(out / f"level_{level}.zarr")
+            xr.testing.assert_allclose(reloaded[["tas"]], dataset[["tas"]])
+
+    def test_creates_missing_parent_directories(self, tmp_path: Path) -> None:
+        pyramid = _tiny_pyramid()
+        out = tmp_path / "nested" / "deeper" / "pyramid"
+        save_pyramid_to_s3(pyramid, str(out), mode="w")
+        assert (out / "level_0.zarr").is_dir()
+
+    def test_s3_options_optional_for_local(self, tmp_path: Path) -> None:
+        # since no s3_options supplied a local write must
+        # not construct an S3 client.
+        out = tmp_path / "pyramid"
+        with mock.patch("grid_doctor.helpers.s3fs.S3FileSystem") as fs:
+            save_pyramid_to_s3(_tiny_pyramid(), str(out), mode="w")
+        fs.assert_not_called()
+
+
+class TestSavePyramidToS3Remote:
+    def test_uses_s3_map_store_for_s3_path(self) -> None:
+        class _FakeDataset:
+            store: object = None
+
+            def to_zarr(self, store: object, **kwargs: object) -> None:
+                self.store = store
+
+        dataset = _FakeDataset()
+        with (
+            mock.patch("grid_doctor.helpers.s3fs.S3FileSystem") as fs,
+            mock.patch(
+                "grid_doctor.helpers.s3fs.S3Map", return_value="s3-store"
+            ) as s3_map,
+        ):
+            save_pyramid_to_s3(
+                {0: dataset},  # type: ignore[dict-item]
+                "s3://bucket/pyr",
+                {"key": "x", "secret": "y"},
+                mode="w",
+            )
+        fs.assert_called_once()
+        s3_map.assert_called_once()
+        assert s3_map.call_args.kwargs["root"] == "s3://bucket/pyr/level_0.zarr"
+        assert dataset.store == "s3-store"


### PR DESCRIPTION
This PR allows to route the Zarr store on the target prefix: an "s3://" path keeps the existing S3Map behaviour, any other value is treated as a local directory and passed straight to `to_zarr`. The S3 client is now only constructed for S3 targets, so `s3_options` is optional for local writes.

