### PR TITLE
feat: Replace the static datasets table with an interactive dataset tree 

### DIFF
--- a/.github/workflows/refresh_bucket_list.yml
+++ b/.github/workflows/refresh_bucket_list.yml
@@ -1,0 +1,67 @@
+name: Refresh Waterpark bucket list
+
+# Regenerates docs/assets/waterpark-datasets.json (the bucket list)
+
+
+on:
+  schedule:
+    - cron: "0 4 * * *"  # every 24h at 4am UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-buckets
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install s3fs
+
+      - name: Refresh bucket list
+        env:
+          WATERPARK_S3_KEY: ${{ secrets.WATERPARK_S3_KEY }}
+          WATERPARK_S3_SECRET: ${{ secrets.WATERPARK_S3_SECRET }}
+        run: |
+          if [ -z "$WATERPARK_S3_KEY" ] || [ -z "$WATERPARK_S3_SECRET" ]; then
+            echo "::error::WATERPARK_S3_KEY / WATERPARK_S3_SECRET secrets are not set."
+            exit 1
+          fi
+          python docs/scripts/refresh_buckets.py \
+            --endpoint https://s3.waterpark.dkrz.de \
+            --out docs/assets/waterpark-datasets.json
+
+      - name: Open a PR if the bucket list changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: docs/assets/waterpark-datasets.json
+          branch: bump-waterpark-buckets
+          delete-branch: true
+          commit-message: "chore(waterpark): refresh bucket list"
+          committer: "freva-bot[bot] <freva-bot@users.noreply.github.com>"
+          author: "freva-bot[bot] <freva-bot@users.noreply.github.com>"
+          base: main
+          title: "chore(waterpark): refresh dataset bucket list"
+          body: |
+            Automated refresh of `docs/assets/waterpark-datasets.json`
+            the bucket list (and labels) the live dataset tree reads.
+
+            The live page fetches this JSON directly from GitHub,
+            so the tree updates as soon as this lands on `main`.
+          labels: |
+            automated
+            waterpark

--- a/docs/assets/waterpark-datasets.json
+++ b/docs/assets/waterpark-datasets.json
@@ -3,13 +3,12 @@
     "cmip6",
     "cordex",
     "dyamond",
-    "earthcare",
     "eerie",
     "era5",
     "icdc",
     "icon-dream",
     "nextgems",
-    "orchestra",
+    "obs",
     "palmod"
   ],
   "datasets": {
@@ -29,12 +28,6 @@
       "title": "DYAMOND",
       "label": "Global storm-resolving intercomparison",
       "href": "https://easy.gems.dkrz.de/DYAMOND/index.html",
-      "status": "available"
-    },
-    "earthcare": {
-      "title": "EarthCARE",
-      "label": "Earth Cloud, Aerosol and Radiation Explorer (ESA/JAXA)",
-      "href": "https://www.esa.int/Applications/Observing_the_Earth/EarthCARE",
       "status": "available"
     },
     "eerie": {
@@ -67,11 +60,8 @@
       "href": "https://nextgems-h2020.eu",
       "status": "available"
     },
-    "orchestra": {
-      "title": "ORCESTRA",
-      "label": "Tropical Atlantic field campaign (2024)",
-      "href": "https://orcestra-campaign.org/data.html",
-      "status": "available"
+    "obs": {
+      "title": "obs"
     },
     "palmod": {
       "title": "PalMod",

--- a/docs/assets/waterpark-datasets.json
+++ b/docs/assets/waterpark-datasets.json
@@ -1,0 +1,83 @@
+{
+  "buckets": [
+    "cmip6",
+    "cordex",
+    "dyamond",
+    "earthcare",
+    "eerie",
+    "era5",
+    "icdc",
+    "icon-dream",
+    "nextgems",
+    "orchestra",
+    "palmod"
+  ],
+  "datasets": {
+    "cmip6": {
+      "title": "CMIP6",
+      "label": "Coupled Model Intercomparison Project Phase 6",
+      "href": "https://wcrp-cmip.org/cmip-phase-6-cmip6",
+      "status": "available"
+    },
+    "cordex": {
+      "title": "CORDEX",
+      "label": "Coordinated Regional Climate Downscaling Experiment",
+      "href": "https://cordex.org",
+      "status": "available"
+    },
+    "dyamond": {
+      "title": "DYAMOND",
+      "label": "Global storm-resolving intercomparison",
+      "href": "https://easy.gems.dkrz.de/DYAMOND/index.html",
+      "status": "available"
+    },
+    "earthcare": {
+      "title": "EarthCARE",
+      "label": "Earth Cloud, Aerosol and Radiation Explorer (ESA/JAXA)",
+      "href": "https://www.esa.int/Applications/Observing_the_Earth/EarthCARE",
+      "status": "available"
+    },
+    "eerie": {
+      "title": "EERIE",
+      "label": "Eddy-Rich Earth System Models",
+      "href": "https://dataviewer.eerie-project.eu/home/eddy-rich",
+      "status": "available"
+    },
+    "era5": {
+      "title": "ERA5",
+      "label": "ECMWF Reanalysis v5",
+      "href": "https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5",
+      "status": "available"
+    },
+    "icdc": {
+      "title": "ICDC",
+      "label": "Integrated Climate Data Center",
+      "href": "https://www.cen.uni-hamburg.de/en/icdc",
+      "status": "in-progress"
+    },
+    "icon-dream": {
+      "title": "ICON-DREAM",
+      "label": "DWD ICON Reanalysis",
+      "href": "https://opendata.dwd.de/climate_environment/CDC/help/landing_pages/doi_landingpage_ICON-DREAM_v1-en.html",
+      "status": "available"
+    },
+    "nextgems": {
+      "title": "nextGEMS",
+      "label": "next Generation Earth Modelling Systems",
+      "href": "https://nextgems-h2020.eu",
+      "status": "available"
+    },
+    "orchestra": {
+      "title": "ORCESTRA",
+      "label": "Tropical Atlantic field campaign (2024)",
+      "href": "https://orcestra-campaign.org/data.html",
+      "status": "available"
+    },
+    "palmod": {
+      "title": "PalMod",
+      "label": "Paleoclimate Modelling initiative",
+      "href": "https://www.palmod.de",
+      "status": "available"
+    }
+  }
+}

--- a/docs/assets/waterpark-inspector.js
+++ b/docs/assets/waterpark-inspector.js
@@ -1,0 +1,105 @@
+/*
+   Waterpark inspector add-on
+   Module path defaults to a sibling file in cdn
+*/
+   (function () {
+    "use strict";
+    var CDN_PKG = "@freva-org/" + "data-inspector";
+    var CDN_VER = "3.1.0";
+    var MODULE_URL = window.WATERPARK_INSPECTOR_SRC ||
+      ("https://cdn.jsdelivr.net/npm/" + CDN_PKG + "@" + CDN_VER + "/+esm");
+  
+
+    var HEADER_BG = window.WATERPARK_HEADER_BG || "var(--md-primary-fg-color)";
+    var LOAD_BG = window.WATERPARK_LOAD_BG || "#0d6efd";
+  
+    injectThemeCss();
+  
+    var modPromise = null;
+    function loadModule() { return (modPromise = modPromise || import(MODULE_URL)); }
+  
+    var el = null, Nc = null;
+  
+    async function ensureElement() {
+      var mod = await loadModule();
+      Nc = mod.NcDumpDialogState || { LOADING: "loading", READY: "ready", ERROR: "error" };
+      if (!el) {
+        el = document.createElement("data-inspector");
+        document.body.appendChild(el);
+        el.addEventListener("inspector-submit", function (e) {
+          var file = e.detail && e.detail.file;
+          if (file) run(Array.isArray(file) ? file[0] : file);
+        });
+        el.addEventListener("inspector-close", function () { el.open = false; });
+      }
+      return mod;
+    }
+  
+    async function run(url) {
+      var mod = await ensureElement();
+      el.file = url;
+      // enables 3D Viewer
+      el.zarrUrl = url;
+      el.output = null;
+      el.error = null;
+      el.status = Nc.LOADING;
+      el.open = true;
+      try {
+        var html = await mod.loadZarrMetadataHtml(url, {
+          getAuthHeaders: function () { return {}; },
+        });
+        el.output = html;
+        el.status = Nc.READY;
+      } catch (err) {
+        el.error = String(err && err.message || err);
+        el.status = Nc.ERROR;
+      }
+    }
+  
+    // Hook the tree's Inspect button calls.
+    window.WATERPARK_INSPECT = function (detail) { return run(detail.url); };
+    function injectThemeCss() {
+      if (document.getElementById("wp-insp-theme")) return;
+      var chrome =
+        "--di-bg:var(--md-default-bg-color);" +
+        "--di-fg:var(--md-typeset-color);" +
+        "--di-muted:var(--md-default-fg-color--light);" +
+        "--di-border:var(--md-default-fg-color--lightest);" +
+        "--di-surface:color-mix(in srgb,var(--md-typeset-color) 5%,var(--md-default-bg-color));" +
+        "--di-accent:var(--md-primary-fg-color);";
+      var reprDark =
+        "--xr-font-color0:var(--md-typeset-color);" +
+        "--xr-font-color2:var(--md-typeset-color);" +
+        "--xr-font-color3:var(--md-default-fg-color--light);" +
+        "--xr-border-color:var(--md-default-fg-color--lightest);" +
+        "--xr-disabled-color:var(--md-default-fg-color--light);" +
+        "--xr-background-color:var(--md-default-bg-color);" +
+        "--xr-background-color-row-even:var(--md-default-bg-color);" +
+        "--xr-background-color-row-odd:color-mix(in srgb,var(--md-typeset-color) 8%,var(--md-default-bg-color));";
+      var css =
+        "data-inspector{" + chrome + "}" +
+        "[data-md-color-scheme] data-inspector{" + chrome + "}" +
+        '[data-md-color-scheme="slate"] data-inspector{' + reprDark + "}" +
+        "data-inspector .di-header{background:" + HEADER_BG + ";border-bottom:none;}" +
+        "data-inspector .di-title{color:#fff;}" +
+        "data-inspector .di-title-ico{color:#fff;}" +
+        "data-inspector .di-close{color:#fff;}" +
+        "data-inspector .di-close:hover{background:rgba(255,255,255,.2);color:#fff;}" +
+        "data-inspector .di-pathbar-label{color:#fff;}" +
+        "data-inspector .di-zarr-row{background:rgba(255,255,255,.15);}" +
+        "data-inspector .di-zarr-row .di-muted{color:#fff;}" +
+        "data-inspector .di-btn-primary{background:" + LOAD_BG + ";border-color:" + LOAD_BG + ";color:#fff;}" +
+
+        "data-inspector{" +
+          "--xr-chunk-face:color-mix(in srgb,var(--md-primary-fg-color) 85%,#fff);" +
+          "--xr-chunk-top:color-mix(in srgb,var(--md-primary-fg-color) 70%,#fff);" +
+          "--xr-chunk-side:color-mix(in srgb,var(--md-primary-fg-color) 60%,#000);" +
+          "--xr-chunk-edge:var(--md-primary-fg-color);" +
+        "}" +
+        // Full-width metadata and lift the repr's built-in 700px cap
+        "data-inspector .xr-wrap{max-width:none!important;}";
+      var s = document.createElement("style");
+      s.id = "wp-insp-theme"; s.textContent = css;
+      document.head.appendChild(s);
+    }
+  })();

--- a/docs/assets/waterpark-tree.css
+++ b/docs/assets/waterpark-tree.css
@@ -1,0 +1,289 @@
+/* 
+   Waterpark dataset tree
+   Important: Colours/typography inherit from Material tokens (--md-*) when present, and
+   fall back to  defaults
+*/
+
+   .wp {
+    --wp-fg:        var(--md-typeset-color, #1a1a1a);
+    --wp-muted:     var(--md-default-fg-color--light, #6b6f76);
+    --wp-faint:     var(--md-default-fg-color--lighter, #9aa0a6);
+    --wp-line:      var(--md-default-fg-color--lightest, #e3e5e8);
+    --wp-bg:        var(--md-default-bg-color, #ffffff);
+    --wp-panel:     color-mix(in srgb, var(--wp-fg) 4%, var(--wp-bg));
+    --wp-primary:   var(--md-primary-fg-color, #009688);
+    --wp-accent:    var(--md-accent-fg-color, #f5a623);
+    --wp-code-bg:   var(--md-code-bg-color, #f4f4f5);
+    --wp-code-fg:   var(--md-code-fg-color, #24292e);
+    --wp-mono:      var(--md-code-font-family, ui-monospace, "SFMono-Regular", "Cascadia Code", Consolas, monospace);
+  
+    font-size: .82rem;
+    line-height: 1.5;
+    color: var(--wp-fg);
+    border: 1px solid var(--wp-line);
+    border-radius: .55rem;
+    overflow: hidden;
+    background: var(--wp-bg);
+  }
+  
+  /* toolbar */
+  .wp__bar {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .5rem .6rem;
+    border-bottom: 1px solid var(--wp-line);
+    background: var(--wp-panel);
+  }
+  .wp__search {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    min-width: 0;
+  }
+  .wp__search svg { flex: 0 0 auto; width: 15px; height: 15px; color: var(--wp-faint); }
+  .wp__search input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--wp-fg);
+    font: inherit;
+  }
+  .wp__search input::placeholder { color: var(--wp-faint); }
+  
+  .wp__btn {
+    appearance: none;
+    border: 1px solid var(--wp-line);
+    background: var(--wp-bg);
+    color: var(--wp-muted);
+    font: inherit;
+    font-size: .72rem;
+    padding: .22rem .5rem;
+    border-radius: .35rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color .12s, border-color .12s, background .12s;
+  }
+  .wp__btn:hover { color: var(--wp-accent); border-color: var(--wp-accent); }
+  .wp__btn:focus-visible { outline: 2px solid var(--wp-accent); outline-offset: 1px; }
+  
+  .wp__mode {
+    font-size: .68rem;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--wp-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+  .wp__dot { width: 7px; height: 7px; border-radius: 50%; background: var(--wp-faint); }
+  .wp__mode--live  .wp__dot { background: #2ec26a; box-shadow: 0 0 0 0 rgba(46,194,106,.6); animation: wp-pulse 2s infinite; }
+  .wp__mode--snap  .wp__dot { background: var(--wp-primary); }
+  @keyframes wp-pulse { 70% { box-shadow: 0 0 0 6px rgba(46,194,106,0); } 100% { box-shadow: 0 0 0 0 rgba(46,194,106,0); } }
+  
+  /* tree */
+  .wp__tree { padding: .25rem 0; max-height: 32rem; overflow: auto; }
+  .wp__tree ul { list-style: none; margin: 0; padding: 0; }
+  .wp__tree li { margin: 0; }
+  
+  /* indentation guide rails */
+  .wp__children { position: relative; padding-left: 1.05rem; }
+  .wp__children::before {
+    content: "";
+    position: absolute;
+    left: .52rem; top: 0; bottom: .35rem;
+    width: 1px;
+    background: var(--wp-line);
+  }
+  
+  /* a single row */
+  .wp__row {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    width: 100%;
+    padding: .26rem .6rem .26rem .35rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    border-radius: .3rem;
+  }
+  .wp__row:hover { background: var(--wp-panel); }
+  .wp__row:focus-visible { outline: 2px solid var(--wp-accent); outline-offset: -2px; }
+  
+  .wp__chev {
+    flex: 0 0 auto;
+    width: 14px; height: 14px;
+    color: var(--wp-faint);
+    transition: transform .15s ease;
+  }
+  .wp__row[aria-expanded="true"] > .wp__chev { transform: rotate(90deg); }
+  .wp__chev--leaf { visibility: hidden; }
+  
+  .wp__icon { flex: 0 0 auto; width: 16px; height: 16px; }
+  .wp__icon--dir   { color: var(--wp-faint); }
+  .wp__icon--store { color: var(--wp-primary); }
+  
+  .wp__name { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .wp__name--store { font-family: var(--wp-mono); font-size: .92em; color: var(--wp-code-fg); }
+  
+  /* dataset (bucket) header row carries the rich metadata */
+  .wp__bucket > .wp__row { padding-block: .42rem; }
+  .wp__bucket-title { font-weight: 600; }
+  .wp__bucket-sub   { color: var(--wp-muted); font-size: .9em; }
+  .wp__doclink {
+    color: var(--wp-faint);
+    text-decoration: none;
+    display: inline-flex;
+    margin-left: .1rem;
+  }
+  .wp__doclink:hover { color: var(--wp-accent); }
+  .wp__doclink svg { width: 12px; height: 12px; }
+  
+  .wp__spacer { flex: 1 1 auto; }
+  
+  /* status + meta chips */
+  .wp__badge {
+    flex: 0 0 auto;
+    font-size: .62rem;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+    padding: .12rem .4rem;
+    border-radius: 1rem;
+    border: 1px solid transparent;
+    white-space: nowrap;
+  }
+  .wp__badge--ok   { color: var(--wp-primary); border-color: color-mix(in srgb, var(--wp-primary) 40%, transparent); background: color-mix(in srgb, var(--wp-primary) 9%, transparent); }
+  .wp__badge--wip  { color: var(--wp-accent);  border-color: color-mix(in srgb, var(--wp-accent) 45%, transparent);  background: color-mix(in srgb, var(--wp-accent) 12%, transparent); }
+  .wp__lvl {
+    flex: 0 0 auto;
+    font-family: var(--wp-mono);
+    font-size: .64rem;
+    color: var(--wp-muted);
+    border: 1px solid var(--wp-line);
+    border-radius: .3rem;
+    padding: .04rem .32rem;
+  }
+  .wp__size { flex: 0 0 auto; font-size: .68rem; color: var(--wp-faint); font-variant-numeric: tabular-nums; }
+  
+  /* store detail panel */
+  .wp__detail {
+    margin: .1rem .6rem .5rem 1.7rem;
+    padding: .6rem .7rem;
+    border: 1px solid var(--wp-line);
+    border-left: 2px solid var(--wp-primary);
+    border-radius: .4rem;
+    background: var(--wp-panel);
+  }
+  .wp__detail[hidden] { display: none; }
+  .wp__actions {
+    display: flex; align-items: center; gap: .4rem; margin-bottom: .45rem;
+  }
+  .wp__fname {
+    font-family: var(--wp-mono); font-weight: 600; font-size: .78rem;
+    color: var(--wp-code-fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .wp__path {
+    display: flex; align-items: center;
+    font-family: var(--wp-mono); font-size: .74rem;
+    color: var(--wp-code-fg);
+    background: var(--wp-code-bg);
+    border-radius: .3rem;
+    padding: .35rem .5rem;
+    overflow-x: auto;
+  }
+  .wp__path code { background: none; padding: 0; white-space: nowrap; }
+  .wp__copy {
+    flex: 0 0 auto;
+    appearance: none;
+    border: 1px solid var(--wp-line);
+    background: var(--wp-bg);
+    color: var(--wp-muted);
+    border-radius: .35rem;
+    padding: .24rem .6rem;
+    font: inherit; font-size: .72rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color .12s, border-color .12s, background .12s;
+  }
+  .wp__copy:hover { color: var(--wp-accent); border-color: var(--wp-accent); }
+  .wp__copy.is-done { color: var(--wp-primary); border-color: var(--wp-primary); }
+  .wp__inspect {
+    background: var(--wp-primary); border-color: var(--wp-primary);
+    color: #fff; font-weight: 600;
+  }
+  .wp__inspect:hover {
+    color: #fff; border-color: transparent;
+    background: color-mix(in srgb, var(--wp-primary) 85%, #000);
+  }
+  .wp__inspect:focus-visible { outline: 2px solid var(--wp-accent); outline-offset: 1px; }
+  
+  .wp__meta { margin-top: .5rem; display: grid; gap: .4rem; }
+  .wp__metarow { display: flex; gap: .5rem; align-items: baseline; flex-wrap: wrap; }
+  .wp__metakey { flex: 0 0 4.2rem; color: var(--wp-muted); font-size: .7rem; text-transform: uppercase; letter-spacing: .03em; }
+  .wp__chip {
+    font-family: var(--wp-mono);
+    font-size: .68rem;
+    color: var(--wp-code-fg);
+    background: var(--wp-code-bg);
+    border-radius: .3rem;
+    padding: .08rem .38rem;
+  }
+  .wp__chip b { color: var(--wp-primary); font-weight: 600; }
+  
+  /* states */
+  .wp__loading, .wp__empty, .wp__error {
+    padding: 1rem .8rem;
+    color: var(--wp-muted);
+    font-size: .78rem;
+    display: flex; align-items: center; gap: .5rem;
+  }
+  .wp__error { color: #d3504a; }
+  .wp__spin {
+    width: 14px; height: 14px; border-radius: 50%;
+    border: 2px solid var(--wp-line);
+    border-top-color: var(--wp-primary);
+    animation: wp-spin .7s linear infinite;
+  }
+  @keyframes wp-spin { to { transform: rotate(360deg); } }
+   
+  .wp__hidden { display: none !important; }
+  .wp__hit > .wp__name { background: color-mix(in srgb, var(--wp-accent) 28%, transparent); border-radius: .2rem; }
+   
+  .wp__foot {
+    padding: .4rem .6rem;
+    border-top: 1px solid var(--wp-line);
+    background: var(--wp-panel);
+    color: var(--wp-faint);
+    font-size: .68rem;
+    display: flex; gap: .5rem; align-items: center; flex-wrap: wrap;
+  }
+  /* Footer status line */
+  .wp__foot--status .wp__mode {
+    padding: .12rem .5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    border: 1px solid var(--wp-line);
+  }
+  .wp__foot--status .wp__mode--live {
+    color: #2ec26a;
+    border-color: rgba(46, 194, 106, .4);
+    background: rgba(46, 194, 106, .10);
+  }
+  .wp__foot--status .wp__mode--snap {
+    color: var(--wp-primary);
+    border-color: var(--wp-line);
+  }
+  .wp__foot-desc { color: var(--wp-faint); }
+  .wp__foot-desc code { color: var(--wp-muted); }
+   
+  @media (prefers-reduced-motion: reduce) {
+    .wp__chev, .wp__mode--live .wp__dot, .wp__spin { transition: none; animation: none; }
+  }
+

--- a/docs/assets/waterpark-tree.js
+++ b/docs/assets/waterpark-tree.js
@@ -1,0 +1,294 @@
+/* Waterpark dataset tree */
+(() => {
+    "use strict";
+  
+    const SVG = {
+      chevron: '<svg class="wp__chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      dir:     '<svg class="wp__icon wp__icon--dir" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.75 3.5A1.25 1.25 0 013 2.25h3l1.5 1.5h4.5A1.25 1.25 0 0113.25 5v6.75A1.25 1.25 0 0112 13H3a1.25 1.25 0 01-1.25-1.25V3.5z"/></svg>',
+      store:   '<svg class="wp__icon wp__icon--store" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.2l6 3v7.6l-6 3-6-3V4.2l6-3zM8 2.9L3.6 5.1 8 7.3l4.4-2.2L8 2.9zM3 6.3v5l4.4 2.2V8.5L3 6.3zm5.6 7.2L13 11.3v-5L8.6 8.5v5z"/></svg>',
+      link:    '<svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6.5 9.5l3-3M7 4h3a2 2 0 012 2v0M9 12H6a2 2 0 01-2-2v0" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>',
+      search:  '<svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>',
+    };
+    const BADGE = { available: ["wp__badge--ok", "available"], "in-progress": ["wp__badge--wip", "in progress"], planned: ["wp__badge--wip", "planned"] };
+  
+    const humanBytes = (n) => {
+      if (n == null || isNaN(n)) return "";
+      const u = ["B", "KB", "MB", "GB", "TB", "PB"]; let i = 0; n = Number(n);
+      while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+      return (n >= 100 || i === 0 ? Math.round(n) : n.toFixed(1)) + " " + u[i];
+    };
+    const h = (tag, cls, html) => { const e = document.createElement(tag); if (cls) e.className = cls; if (html != null) e.innerHTML = html; return e; };
+  
+    function copy(text, btn) {
+      const done = () => { btn.classList.add("is-done"); const t = btn.textContent; btn.textContent = "Copied"; setTimeout(() => { btn.classList.remove("is-done"); btn.textContent = t; }, 1200); };
+      if (navigator.clipboard?.writeText) navigator.clipboard.writeText(text).then(done, done);
+      else { const ta = document.createElement("textarea"); ta.value = text; document.body.appendChild(ta); ta.select(); document.execCommand("copy"); ta.remove(); done(); }
+    }
+  
+    /*listing back-ends: each returns {dirs:[node], stores:[node]} */
+    const xmlText = (el, tag) => { const n = el.getElementsByTagName(tag)[0]; return n ? n.textContent : null; };
+  
+    async function s3ListBuckets(endpoint) {
+      const res = await fetch(endpoint + "/");
+      if (!res.ok) throw new Error("ListBuckets HTTP " + res.status);
+      const xml = new DOMParser().parseFromString(await res.text(), "application/xml");
+      return [...xml.getElementsByTagName("Bucket")].map((b) => xmlText(b, "Name")).filter(Boolean);
+    }
+  
+    async function s3List(endpoint, bucket, prefix) {
+      const dirs = [], stores = [];
+      let token = null;
+      do {
+        const u = new URL(endpoint + "/" + bucket);
+        u.searchParams.set("list-type", "2");
+        u.searchParams.set("delimiter", "/");
+        if (prefix) u.searchParams.set("prefix", prefix);
+        if (token) u.searchParams.set("continuation-token", token);
+        const res = await fetch(u.toString());
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const xml = new DOMParser().parseFromString(await res.text(), "application/xml");
+        for (const cp of xml.getElementsByTagName("CommonPrefixes")) {
+          const p = xmlText(cp, "Prefix");
+          const name = p.replace(/\/$/, "").split("/").pop();
+          const base = { name, bucket, prefix: p, path: bucket + "/" + p.replace(/\/$/, "") };
+          if (/\.zarr$/i.test(name)) stores.push({ ...base, type: "store", meta: {} });
+          else dirs.push({ ...base, type: "dir" });
+        }
+        for (const c of xml.getElementsByTagName("Contents")) {
+          const key = xmlText(c, "Key");
+          if (!key || key === prefix || /\/$/.test(key)) continue;
+          stores.push({ type: "store", name: key.split("/").pop(), path: bucket + "/" + key, size: +(xmlText(c, "Size") || 0), meta: {} });
+        }
+        const trunc = xmlText(xml, "IsTruncated") === "true";
+        token = trunc ? xmlText(xml, "NextContinuationToken") : null;
+      } while (token);
+      return { dirs, stores };
+    }
+  
+    async function apiList(api, path) {
+      const u = new URL(api, location.href);
+      if (path) u.searchParams.set("path", path);
+      const res = await fetch(u.toString());
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      const j = await res.json();
+      return { dirs: (j.dirs || []).map((d) => ({ ...d, type: "dir" })), stores: (j.stores || []).map((s) => ({ ...s, type: "store", meta: s.meta || {} })) };
+    }
+  
+    function listChildren(ctx, node) {
+      if (ctx.mode === "api") return apiList(ctx.api, node.type === "bucket" ? node.bucket : node.path);
+      return s3List(ctx.endpoint, node.bucket, node.prefix || "");
+    }
+  
+    // node rendering
+    function nodeEl(node, ctx) {
+      const li = h("li");
+      const isStore = node.type === "store";
+      const isBucket = node.type === "bucket";
+      const expandable = !isStore;
+  
+      const row = h("button", "wp__row"); row.type = "button";
+      row.innerHTML = SVG.chevron;
+      if (!expandable) row.querySelector(".wp__chev").classList.add("wp__chev--leaf");
+      row.insertAdjacentHTML("beforeend", isStore ? SVG.store : SVG.dir);
+  
+      const name = h("span", "wp__name" + (isStore ? " wp__name--store" : ""));
+      if (isBucket) {
+        name.classList.add("wp__bucket-title");
+        name.textContent = node.title || node.name;
+        if (node.label) { const s = h("span", "wp__bucket-sub"); s.textContent = "  " + node.label; name.appendChild(s); }
+      } else name.textContent = node.name;
+      row.appendChild(name);
+  
+      if (isBucket && node.href) {
+        const a = h("a", "wp__doclink", SVG.link);
+        a.href = node.href; a.target = "_blank"; a.rel = "noopener"; a.title = "Project page";
+        a.addEventListener("click", (e) => e.stopPropagation());
+        row.appendChild(a);
+      }
+      row.appendChild(h("span", "wp__spacer"));
+      if (isBucket && node.status && BADGE[node.status]) { const [c, t] = BADGE[node.status]; const b = h("span", "wp__badge " + c); b.textContent = t; row.appendChild(b); }
+      if (isStore) {
+        const lvl = node.meta && node.meta.healpix_level;
+        if (lvl != null) { const l = h("span", "wp__lvl"); l.textContent = "HP " + lvl; row.appendChild(l); }
+        if (node.size != null) { const s = h("span", "wp__size"); s.textContent = humanBytes(node.size); row.appendChild(s); }
+      }
+      li.appendChild(row);
+      li._node = node; li._row = row; li._name = (node.title || node.name || "").toLowerCase();
+  
+      if (isStore) {
+        const detail = buildDetail(node, ctx); detail.hidden = true; li.appendChild(detail);
+        row.setAttribute("aria-expanded", "false");
+        row.addEventListener("click", () => { const open = detail.hidden; detail.hidden = !open; row.setAttribute("aria-expanded", String(open)); });
+        return li;
+      }
+  
+      const kids = h("ul", "wp__children"); kids.hidden = true; li.appendChild(kids);
+      row.setAttribute("aria-expanded", "false");
+      li._kids = kids; li._loaded = false;
+      row.addEventListener("click", async () => {
+        const open = kids.hidden;
+        if (open && !li._loaded) { li._loaded = true; await populate(li, node, ctx); }
+        kids.hidden = !open; row.setAttribute("aria-expanded", String(open));
+      });
+      return li;
+    }
+  
+    async function populate(li, node, ctx) {
+      const kids = li._kids;
+      if (!ctx.lazy) { (node.children || []).forEach((c) => kids.appendChild(nodeEl(c, ctx))); return; }
+      const wait = h("div", "wp__loading", '<span class="wp__spin"></span> listing…'); kids.appendChild(wait);
+      try {
+        const { dirs, stores } = await listChildren(ctx, node);
+        wait.remove();
+        dirs.sort((a, b) => a.name.localeCompare(b.name)).forEach((d) => kids.appendChild(nodeEl(d, ctx)));
+        stores.sort((a, b) => a.name.localeCompare(b.name)).forEach((s) => kids.appendChild(nodeEl(s, ctx)));
+        if (!kids.children.length) kids.appendChild(h("div", "wp__empty", "empty"));
+      } catch (err) {
+        wait.remove();
+        kids.appendChild(h("div", "wp__error", "Could not list — " + err.message + (ctx.mode === "live" ? " (likely CORS or anonymous listing is disabled on the endpoint)" : "")));
+      }
+    }
+  
+    function buildDetail(node, ctx) {
+      const wrap = h("div", "wp__detail");
+      const s3path = "s3://" + node.path;
+      const httpUrl = ctx && ctx.endpoint ? ctx.endpoint.replace(/\/$/, "") + "/" + node.path : null;
+  
+      // An effort to keep actions live on their own row so they never scroll out of view, with
+      // Inspect as the primary action
+      const actions = h("div", "wp__actions");
+      const fname = h("span", "wp__fname"); fname.textContent = node.name;
+      const cb = h("button", "wp__copy"); cb.type = "button"; cb.textContent = "Copy path";
+      cb.addEventListener("click", () => copy(s3path, cb));
+      actions.append(fname, h("span", "wp__spacer"), cb);
+      if (httpUrl && typeof window.WATERPARK_INSPECT === "function") {
+        const ib = h("button", "wp__copy wp__inspect"); ib.type = "button"; ib.textContent = "Inspect";
+        ib.addEventListener("click", () => window.WATERPARK_INSPECT({ url: httpUrl, name: node.name, path: node.path }));
+        actions.append(ib);
+      }
+      wrap.appendChild(actions);
+  
+      // Full-width path pill that scrolls horizontally on its own
+      const path = h("div", "wp__path", `<code>${s3path}</code>`);
+      wrap.appendChild(path);
+  
+      const m = node.meta || {}; const meta = h("div", "wp__meta");
+      if (m.dims && Object.keys(m.dims).length) {
+        const r = h("div", "wp__metarow", '<span class="wp__metakey">dims</span>');
+        Object.entries(m.dims).forEach(([k, v]) => r.appendChild(h("span", "wp__chip", `${k} <b>${Number(v).toLocaleString()}</b>`)));
+        meta.appendChild(r);
+      }
+      if (m.vars && m.vars.length) {
+        const r = h("div", "wp__metarow", '<span class="wp__metakey">vars</span>');
+        m.vars.slice(0, 12).forEach((v) => { const c = h("span", "wp__chip"); c.textContent = v; r.appendChild(c); });
+        if (m.vars.length > 12) { const c = h("span", "wp__chip"); c.textContent = "+" + (m.vars.length - 12); r.appendChild(c); }
+        meta.appendChild(r);
+      }
+      if (m.title) { const r = h("div", "wp__metarow", '<span class="wp__metakey">title</span>'); const c = h("span", "wp__bucket-sub"); c.textContent = m.title; r.appendChild(c); meta.appendChild(r); }
+      if (meta.children.length) wrap.appendChild(meta);
+      return wrap;
+    }
+  
+    // filter (searches loaded levels; static also pulls children in)
+    function filter(rootUl, q, ctx) {
+      q = q.trim().toLowerCase();
+      const walk = (ul) => {
+        let any = false;
+        [...ul.children].forEach((li) => {
+          if (!li._row) return;
+          const selfHit = q && li._name.includes(q);
+          let kidHit = false;
+          if (li._kids) {
+            if (q && !li._loaded && !ctx.lazy && li._node) { li._loaded = true; (li._node.children || []).forEach((c) => li._kids.appendChild(nodeEl(c, ctx))); }
+            kidHit = walk(li._kids);
+            if (q) { li._kids.hidden = !kidHit; li._row.setAttribute("aria-expanded", String(kidHit)); }
+            else { li._kids.hidden = true; li._row.setAttribute("aria-expanded", "false"); }
+          }
+          const show = !q || selfHit || kidHit;
+          li.classList.toggle("wp__hidden", !show);
+          li._row.classList.toggle("wp__hit", !!(q && selfHit));
+          any = any || show;
+        });
+        return any;
+      };
+      walk(rootUl);
+    }
+  
+    //mount
+    async function loadData(host, ctx) {
+      if (window.WATERPARK_DATA) return window.WATERPARK_DATA;
+      if (ctx.mode === "static") {
+        const res = await fetch(host.dataset.src || "assets/waterpark-index.json");
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      }
+      // optional shared metadata map
+      let meta = {};
+      if (host.dataset.meta) {
+        try { const r = await fetch(host.dataset.meta); if (r.ok) { const m = await r.json(); meta = m.datasets || m || {}; } } catch (_) { /* metadata is optional */ }
+      }
+      // lazy modes: build the bucket list, children load on expand
+      let buckets = (host.dataset.buckets || "").split(",").map((s) => s.trim()).filter(Boolean);
+      if (!buckets.length) {
+        if (ctx.mode === "live") buckets = await s3ListBuckets(ctx.endpoint);
+        else {
+          const top = await apiList(ctx.api, "");
+          return { endpoint: ctx.endpoint, datasets: top.dirs.map((d) => { const b = d.bucket || d.name; return { type: "bucket", bucket: b, name: b, title: b, path: b, prefix: "", status: "available", ...d, ...(meta[b] || {}) }; }) };
+        }
+      }
+      return { endpoint: ctx.endpoint, datasets: buckets.map((b) => ({ type: "bucket", bucket: b, name: b, title: b, path: b, prefix: "", status: "available", ...(meta[b] || {}) })) };
+    }
+  
+    async function mount(host) {
+      const mode = host.dataset.mode || "static";
+      const ctx = { mode, lazy: mode !== "static", endpoint: (host.dataset.endpoint || "").replace(/\/$/, ""), api: (host.dataset.api || "").replace(/\/$/, "") };
+  
+      const bar = h("div", "wp__bar");
+      const search = h("div", "wp__search", SVG.search);
+      const input = h("input"); input.type = "search"; input.placeholder = "Filter datasets and paths…"; input.setAttribute("aria-label", "Filter"); search.appendChild(input);
+      const expand = h("button", "wp__btn"); expand.type = "button"; expand.textContent = "Expand all";
+      if (ctx.lazy) expand.classList.add("wp__hidden");  // no bulk expand when children load on demand
+      const collapse = h("button", "wp__btn"); collapse.type = "button"; collapse.textContent = "Collapse";
+      const liveMode = mode === "live" || mode === "api";
+      bar.append(search, expand, collapse); host.appendChild(bar);
+  
+      const treeWrap = h("div", "wp__tree"); const rootUl = h("ul", "wp__root"); rootUl._ctx = ctx; treeWrap.appendChild(rootUl);
+      const foot = h("div", "wp__foot wp__foot--status");
+      const loading = h("div", "wp__loading", '<span class="wp__spin"></span> loading datasets…');
+      host.appendChild(loading);
+  
+      let data;
+      try { data = await loadData(host, ctx); }
+      catch (err) { loading.replaceWith(h("div", "wp__error", "Could not load datasets — " + err.message + (ctx.mode === "live" ? " (anonymous ListBuckets may be disabled; set data-buckets, or use static/api mode)" : ""))); return; }
+  
+      loading.replaceWith(treeWrap); host.appendChild(foot);
+      if (!ctx.endpoint && data.endpoint) ctx.endpoint = data.endpoint.replace(/\/$/, "");
+      (data.datasets || []).forEach((d) => {
+        const node = Object.assign({ type: "bucket", name: d.bucket, path: d.bucket || d.name, prefix: "" }, d);
+        if (!ctx.lazy && d.tree) node.children = d.tree.children || [];
+        rootUl.appendChild(nodeEl(node, ctx));
+      });
+  
+      // Footer
+      const fbadge = h("span", "wp__mode " + (liveMode ? "wp__mode--live" : "wp__mode--snap"),
+        '<span class="wp__dot"></span>' + (liveMode ? "LIVE" : "SNAPSHOT"));
+      const fdesc = h("span", "wp__foot-desc");
+      fdesc.innerHTML = liveMode
+        ? `${ctx.mode === "api" ? "via backend" : "direct S3 listing"}${data.endpoint ? " of <code>" + data.endpoint + "</code>" : ""}`
+        : `${data.generated ? new Date(data.generated).toISOString().slice(0, 16).replace("T", " ") + " UTC" : "prebuilt index"}${data.endpoint ? " · <code>" + data.endpoint + "</code>" : ""}`;
+      foot.append(fbadge, fdesc);
+  
+      expand.addEventListener("click", () => { if (ctx.lazy) return; rootUl.querySelectorAll("li").forEach((li) => { if (li._kids && li._kids.hidden) li._row.click(); }); });
+      collapse.addEventListener("click", () => {
+        input.value = "";
+        [...rootUl.children].forEach((li) => { if (li._kids) { li._kids.hidden = true; li._row.setAttribute("aria-expanded", "false"); } });
+        rootUl.querySelectorAll(".wp__hidden").forEach((e) => e.classList.remove("wp__hidden"));
+        rootUl.querySelectorAll(".wp__hit").forEach((e) => e.classList.remove("wp__hit"));
+      });
+      let t; input.addEventListener("input", () => { clearTimeout(t); t = setTimeout(() => filter(rootUl, input.value, ctx), 120); });
+    }
+  
+    function init() { document.querySelectorAll("[data-waterpark]").forEach((el) => { if (!el._wpInit) { el._wpInit = true; mount(el); } }); }
+    if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init); else init();
+    if (window.document$ && window.document$.subscribe) window.document$.subscribe(init);
+  })();

--- a/docs/assets/waterpark-tree.js
+++ b/docs/assets/waterpark-tree.js
@@ -222,13 +222,41 @@
         if (!res.ok) throw new Error("HTTP " + res.status);
         return res.json();
       }
-      // optional shared metadata map
-      let meta = {};
-      if (host.dataset.meta) {
-        try { const r = await fetch(host.dataset.meta); if (r.ok) { const m = await r.json(); meta = m.datasets || m || {}; } } catch (_) { /* metadata is optional */ }
+      // Shared metadata
+      async function fetchMeta(url, timeoutMs) {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), timeoutMs || 2500);
+        try {
+          const r = await fetch(url, { signal: ctrl.signal });
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return await r.json();
+        } finally {
+          clearTimeout(t);
+        }
       }
+  
+      let metaRaw = {};
+      // first fetch raw GitHub, then automatically fall back to the 
+      // same-named file shipped locally in assets/ then get the bucket
+      // only names from md file
+      const metaSources = [];
+      if (host.dataset.meta) {
+        metaSources.push(host.dataset.meta);
+        const localName = host.dataset.meta.split("/").pop().split("?")[0];
+        if (localName) metaSources.push("../assets/" + localName);
+      }
+      for (const url of metaSources) {
+        try { metaRaw = await fetchMeta(url, 2500); break; }
+        catch (_) { /* try the next source */ }
+      }
+      const meta = metaRaw.datasets || metaRaw || {};
+
       // lazy modes: build the bucket list, children load on expand
-      let buckets = (host.dataset.buckets || "").split(",").map((s) => s.trim()).filter(Boolean);
+      let buckets = (Array.isArray(metaRaw.buckets) ? metaRaw.buckets : [])
+        .map((s) => String(s).trim()).filter(Boolean);
+      if (!buckets.length) {
+        buckets = (host.dataset.buckets || "").split(",").map((s) => s.trim()).filter(Boolean);
+      }
       if (!buckets.length) {
         if (ctx.mode === "live") buckets = await s3ListBuckets(ctx.endpoint);
         else {

--- a/docs/scripts/refresh_buckets.py
+++ b/docs/scripts/refresh_buckets.py
@@ -1,0 +1,75 @@
+"""
+Refresh docs/assets/waterpark-datasets.json from the live bucket listing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import s3fs
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_OUT = HERE.parent.parent / "docs" / "assets" / "waterpark-datasets.json"
+
+
+def list_buckets(endpoint: str, key: str, secret: str) -> list[str]:
+    fs = s3fs.S3FileSystem(key=key, secret=secret,
+                           client_kwargs={"endpoint_url": endpoint})
+    names: list[str] = []
+    for root in ("", "/"):
+        try:
+            items = fs.ls(root, detail=False)
+            names = [i.strip("/").split("/")[-1] for i in items if i.strip("/")]
+            if names:
+                break
+        except Exception as exc:
+            last = exc
+    if not names:
+        raise SystemExit(f"could not list buckets from {endpoint} "
+                         f"(check admin credentials / gateway permissions)")
+    return sorted(names)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--endpoint", default="https://s3.waterpark.dkrz.de")
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args()
+
+    key = os.environ.get("WATERPARK_S3_KEY")
+    secret = os.environ.get("WATERPARK_S3_SECRET")
+    if not key or not secret:
+        raise SystemExit("set WATERPARK_S3_KEY and WATERPARK_S3_SECRET in the environment")
+
+    buckets = list_buckets(args.endpoint, key, secret)
+
+    # chec if the JSON is already there.
+    existing: dict = {}
+    if args.out.exists():
+        try:
+            existing = json.loads(args.out.read_text()).get("datasets", {})
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    # Reconcile: keep existing descriptions add new buckets bare, drop the rest.
+    datasets = {b: existing.get(b, {"title": b}) for b in buckets}
+
+    added = [b for b in buckets if b not in existing]
+    removed = [b for b in existing if b not in buckets]
+
+    payload = {"buckets": buckets, "datasets": datasets}
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2) + "\n")
+
+    print(f"wrote {args.out}  ({len(buckets)} buckets)", file=sys.stderr)
+    if added:
+        print(f"added (no description): {', '.join(added)}", file=sys.stderr)
+    if removed:
+        print(f"removed: {', '.join(removed)}", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/refresh_buckets.py
+++ b/docs/scripts/refresh_buckets.py
@@ -47,7 +47,7 @@ def main() -> None:
 
     buckets = list_buckets(args.endpoint, key, secret)
 
-    # chec if the JSON is already there.
+    # check if the JSON is already there.
     existing: dict = {}
     if args.out.exists():
         try:

--- a/docs/waterpark.md
+++ b/docs/waterpark.md
@@ -17,7 +17,7 @@ visualisation without per-dataset regridding at access time.
      data-mode="live"
      data-endpoint="https://s3.waterpark.dkrz.de"
      data-buckets="cmip6,cordex,dyamond,earthcare,eerie,era5,icdc,icon-dream,nextgems,orchestra,palmod"
-     data-meta="../assets/waterpark-datasets.json"></div>
+     data-meta="https://raw.githubusercontent.com/freva-org/grid-doctor/main/docs/assets/waterpark-datasets.json"></div>
 
 
 !!! warning "Preliminary test data"

--- a/docs/waterpark.md
+++ b/docs/waterpark.md
@@ -13,16 +13,11 @@ visualisation without per-dataset regridding at access time.
 
 ### Currently available Datasets
 
-| Dataset | Data Access via |
-|---------|-----------------|
-| [CMIP6](https://wcrp-cmip.org/cmip-phase-6-cmip6)   | `s3://cimp6` |
-| [DYAMOND](https://easy.gems.dkrz.de/DYAMOND/index.html)   | `s3://dyamond` |
-| [EERIE](https://dataviewer.eerie-project.eu/home/eddy-rich)   | `s3://eerie` |
-| [ERA5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5)   | `s3://era5 `|
-| [ICDC](https://www.cen.uni-hamburg.de/en/icdc) | `s3://icdc` |
-| [ICON-DREAM](https://opendata.dwd.de/climate_environment/CDC/help/landing_pages/doi_landingpage_ICON-DREAM_v1-en.html) | `s3://icon-dream` |
-| [nextGEMS](https://nextgems-h2020.eu) | `s3://nextgems` |
-| [ORCESTRA](https://orcestra-campaign.org/data.html) |`s3://orchsestra`|
+<div class="wp" data-waterpark
+     data-mode="live"
+     data-endpoint="https://s3.waterpark.dkrz.de"
+     data-buckets="cmip6,cordex,dyamond,earthcare,eerie,era5,icdc,icon-dream,nextgems,orchestra,palmod"
+     data-meta="../assets/waterpark-datasets.json"></div>
 
 
 !!! warning "Preliminary test data"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,9 +82,12 @@ markdown_extensions:
 
 extra_css:
   - assets/styles.css
+  - assets/waterpark-tree.css
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - assets/waterpark-tree.js
+  - assets/waterpark-inspector.js
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
In this PR we swaps the hand-maintained "Currently available Datasets" markdown table on the Waterpark page for an interactive, themeable directory tree of the S3/Zarr stores, with a per-store metadata inspector.

One catch keeps the tree from being fully automated: only an admin with credentials can list the buckets. Versity intentionally prevents clients from listing buckets anonymously, so the bucket list has to be supplied rather than discovered.