### PR TITLE
change: Add two independent ways to control which buckets show in the docs tree

### DIFF
--- a/.github/workflows/refresh_bucket_list.yml
+++ b/.github/workflows/refresh_bucket_list.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           WATERPARK_S3_KEY: ${{ secrets.WATERPARK_S3_KEY }}
           WATERPARK_S3_SECRET: ${{ secrets.WATERPARK_S3_SECRET }}
+          WATERPARK_BUCKET_BLACKLIST: ${{ vars.WATERPARK_BUCKET_BLACKLIST }}
         run: |
           if [ -z "$WATERPARK_S3_KEY" ] || [ -z "$WATERPARK_S3_SECRET" ]; then
             echo "::error::WATERPARK_S3_KEY / WATERPARK_S3_SECRET secrets are not set."

--- a/docs/assets/waterpark-datasets.json
+++ b/docs/assets/waterpark-datasets.json
@@ -9,7 +9,8 @@
     "icon-dream",
     "nextgems",
     "obs",
-    "palmod"
+    "palmod",
+    "xpies"
   ],
   "datasets": {
     "cmip6": {
@@ -59,6 +60,11 @@
     "palmod": {
       "title": "PalMod",
       "label": "Paleoclimate Modelling initiative"
+    },
+    "xpies": {
+      "title": "xpies",
+      "label": "XPIES simulations",
+      "locked": "coming soon"
     }
   }
 }

--- a/docs/assets/waterpark-tree.js
+++ b/docs/assets/waterpark-tree.js
@@ -146,6 +146,8 @@
       if (ctx.mode !== "live") return;
       const items = [...rootUl.children].filter((li) => li._bucketRow && li.dataset.bucket);
       await Promise.all(items.map(async (li) => {
+        // never probes for data for locked tags
+        if (li._node && li._node.locked) return;
         const has = await s3HasObjects(ctx.endpoint, li.dataset.bucket);
         // null (probe failed); leave unlabeled
         if (has !== null) setNoData(li._bucketRow, has);
@@ -162,9 +164,11 @@
       const li = h("li");
       const isStore = node.type === "store";
       const isBucket = node.type === "bucket";
+      // A bucket flagged locked is shown but not browsable
+      const locked = isBucket && !!node.locked;
       // loose file, not a .zarr store
       const nonZarr = isStore && node.zarr === false;
-      const expandable = !isStore;
+      const expandable = !isStore && !locked;
   
       const row = h("button", "wp__row"); row.type = "button";
       row.innerHTML = SVG.chevron;
@@ -198,6 +202,14 @@
       li.appendChild(row);
       li._node = node; li._row = row; li._name = (node.title || node.name || "").toLowerCase();
   
+      if (locked) {
+        // a "coming soon" badge
+        const b = h("span", "wp__badge wp__badge--nodata");
+        b.innerHTML = '<span class="wp__badge-dot"></span>' + (typeof node.locked === "string" ? node.locked : "coming soon");
+        row.appendChild(b);
+        return li;
+      }
+
       if (isStore) {
         //inert: hoverable row, but no detail/actions/click
         if (nonZarr) return li;

--- a/docs/scripts/refresh_buckets.py
+++ b/docs/scripts/refresh_buckets.py
@@ -47,6 +47,11 @@ def main() -> None:
 
     buckets = list_buckets(args.endpoint, key, secret)
 
+    # Blacklist
+    blacklist = {b.strip() for b in os.environ.get("WATERPARK_BUCKET_BLACKLIST", "").split(",") if b.strip()}
+    if blacklist:
+        buckets = [b for b in buckets if b not in blacklist]
+
     # check if the JSON is already there.
     existing: dict = {}
     if args.out.exists():


### PR DESCRIPTION
Through this PR, the docs dataset tree now supports three states per bucket: regular, locked, and blacklisted.
Accidentally created buckets go to the blacklist: listed as a comma-separated value in the organization CI variable `WATERPARK_BUCKET_BLACKLIST`, they're filtered out during the CI refresh so they never reach the page.
Locked buckets are flagged manually in the JSON file (a "locked" entry), which renders them as a non-browsable "coming soon" row.
Regular buckets work exactly as before.