### PR TITLE
Propagate weights across the healpix pyramid when coarsening

### DIFF
--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -149,14 +149,15 @@ def _coarsen_array(
     *,
     factor: int,
     min_valid_fraction: float = 0.5,
-) -> FloatArray:
+    weights: npt.NDArray[np.floating[Any]] | None = None,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Coarsen a HEALPix array by grouping contiguous nested cells.
 
     The last dimension is treated as the cell dimension.  All leading
     dimensions are batch dimensions that are preserved.
 
-    Uses a fused sum/count approach instead of ``np.nanmean`` to
-    avoid redundant NaN detection passes.
+    Uses a fused weighted-sum / weight-sum approach instead of
+    ``np.nanmean`` to avoid redundant NaN detection passes.
 
     Args:
         values: Input array with shape ``(*batch, n_cells)``.
@@ -165,27 +166,50 @@ def _coarsen_array(
             children required.  Parent cells with fewer valid
             children are set to NaN.  Default ``0.5`` (at least
             half of the children must be valid).
+        weights: Optional child weights with the same shape as
+            ``values``.  When omitted, finite children receive weight
+            1 and NaN children receive weight 0.
 
     Returns:
-        Array with shape ``(*batch, n_cells // factor)``.
+        Tuple ``(coarsened_values, parent_weights)`` where both arrays
+        have shape ``(*batch, n_cells // factor)``.
+
+        ``parent_weights`` is the valid-weight fraction in ``[0, 1]``
+        after thresholding.  Values that fail ``min_valid_fraction``
+        receive weight 0.
     """
     arr = np.asarray(values, dtype=np.float64)
+    if weights is None:
+        child_weights = np.where(np.isfinite(arr), 1.0, 0.0)
+    else:
+        child_weights = np.asarray(weights, dtype=np.float64)
+        if child_weights.shape != arr.shape:
+            raise ValueError("weights must have the same shape as values.")
+
     batch_shape = arr.shape[:-1]
     n_cells = arr.shape[-1]
     n_target = n_cells // factor
     grouped = arr.reshape(*batch_shape, n_target, factor)
-    valid = np.isfinite(grouped)
-    valid_count = valid.sum(axis=-1)
-    filled = np.where(valid, grouped, 0.0)
+    grouped_weights = child_weights.reshape(*batch_shape, n_target, factor)
 
-    min_count = max(1, int(np.ceil(min_valid_fraction * factor)))
+    valid = (
+        np.isfinite(grouped)
+        & np.isfinite(grouped_weights)
+        & (grouped_weights > 0.0)
+    )
+    used_weights = np.where(valid, grouped_weights, 0.0)
+    weight_sum = used_weights.sum(axis=-1)
+    weighted_values = np.where(valid, grouped * grouped_weights, 0.0)
+
+    min_weight = max(1.0, float(np.ceil(min_valid_fraction * factor)))
+    parent_weights = np.where(weight_sum >= min_weight, weight_sum / factor, 0.0)
     with np.errstate(invalid="ignore"):
         result = np.where(
-            valid_count >= min_count,
-            filled.sum(axis=-1) / valid_count,
+            weight_sum >= min_weight,
+            weighted_values.sum(axis=-1) / weight_sum,
             np.nan,
         )
-    return cast(FloatArray, result)
+    return result, parent_weights
 
 
 def _coarsen_array_mode(
@@ -248,7 +272,10 @@ def coarsen_healpix(
     target_level: int,
     coarsen_mode: CoarsenMode = "auto",
     min_valid_fraction: float = 0.5,
-) -> xr.Dataset:
+    *,
+    child_weights: dict[str, xr.DataArray] | None = None,
+    return_weights: bool = False,
+) -> xr.Dataset | tuple[xr.Dataset, dict[str, xr.DataArray]]:
     """Coarsen a HEALPix dataset to a lower-resolution level.
 
     The coarsening is performed as a single reshape + reduction over
@@ -271,11 +298,20 @@ def coarsen_healpix(
         produce a valid parent cell.  Parents with fewer valid
         children are set to NaN.  Default ``0.5`` (at least half
         of the children must be valid).
+    child_weights:
+        Optional per-variable child weights for ``cell``-resolved
+        variables.  When omitted, finite child values are weighted as
+        1 and NaNs as 0.
+    return_weights:
+        When ``True``, return a tuple ``(coarsened_dataset,
+        parent_weights)`` where ``parent_weights`` is a dictionary of
+        propagated per-variable valid-weight fractions.
 
     Returns
     -------
-    xarray.Dataset
-        Coarsened dataset.
+    xarray.Dataset or tuple[xarray.Dataset, dict[str, xarray.DataArray]]
+        Coarsened dataset.  When ``return_weights=True``, also returns
+        propagated per-variable parent weights.
 
     Notes
     -----
@@ -320,35 +356,82 @@ def coarsen_healpix(
     else:
         resolved_mode = coarsen_mode
 
-    coarsen_func = _coarsen_array_mode if resolved_mode == "mode" else _coarsen_array
-
     factor = 4**delta_level
     npix_target = ds.sizes["cell"] // factor
 
     coarsened_vars: dict[str, xr.DataArray] = {}
+    output_weights: dict[str, xr.DataArray] = {}
     for name, data in ds.data_vars.items():
         if "cell" not in data.dims:
             coarsened_vars[str(name)] = data
             continue
 
-        coarsened_vars[str(name)] = cast(
-            xr.DataArray,
+        if resolved_mode == "mode":
+            coarsened_vars[str(name)] = cast(
+                xr.DataArray,
+                xr.apply_ufunc(
+                    _coarsen_array_mode,
+                    data,
+                    input_core_dims=[["cell"]],
+                    output_core_dims=[["cell"]],
+                    exclude_dims={"cell"},
+                    dask="parallelized",
+                    kwargs={
+                        "factor": factor,
+                        "min_valid_fraction": min_valid_fraction,
+                    },
+                    output_dtypes=[np.float64],
+                    dask_gufunc_kwargs={"output_sizes": {"cell": npix_target}},
+                    keep_attrs=True,
+                ),
+            )
+            # Keep a simple availability fraction for downstream weighted means.
+            output_weights[str(name)] = cast(
+                xr.DataArray,
+                xr.apply_ufunc(
+                    _coarsen_array,
+                    data,
+                    xr.where(np.isfinite(data), 1.0, 0.0),
+                    input_core_dims=[["cell"], ["cell"]],
+                    output_core_dims=[["cell"], ["cell"]],
+                    exclude_dims={"cell"},
+                    dask="parallelized",
+                    kwargs={
+                        "factor": factor,
+                        "min_valid_fraction": min_valid_fraction,
+                    },
+                    output_dtypes=[np.float64, np.float64],
+                    dask_gufunc_kwargs={"output_sizes": {"cell": npix_target}},
+                )[1],
+            )
+            continue
+
+        var_weights = (
+            child_weights[str(name)]
+            if child_weights is not None and str(name) in child_weights
+            else xr.where(np.isfinite(data), 1.0, 0.0)
+        )
+        coarsened_data, parent_weights = cast(
+            tuple[xr.DataArray, xr.DataArray],
             xr.apply_ufunc(
-                coarsen_func,
+                _coarsen_array,
                 data,
-                input_core_dims=[["cell"]],
-                output_core_dims=[["cell"]],
+                var_weights,
+                input_core_dims=[["cell"], ["cell"]],
+                output_core_dims=[["cell"], ["cell"]],
                 exclude_dims={"cell"},
                 dask="parallelized",
                 kwargs={
                     "factor": factor,
                     "min_valid_fraction": min_valid_fraction,
                 },
-                output_dtypes=[np.float64],
+                output_dtypes=[np.float64, np.float64],
                 dask_gufunc_kwargs={"output_sizes": {"cell": npix_target}},
                 keep_attrs=True,
             ),
         )
+        coarsened_vars[str(name)] = coarsened_data
+        output_weights[str(name)] = parent_weights
 
     result = xr.Dataset(coarsened_vars, attrs=ds.attrs.copy())
     lat_deg, lon_deg = _healpix_coords(target_level, nest=True)
@@ -372,6 +455,8 @@ def coarsen_healpix(
     result.attrs["healpix_level"] = target_level
     result.attrs["healpix_order"] = "nested"
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
+    if return_weights:
+        return result, output_weights
     return result
 
 
@@ -433,12 +518,22 @@ def create_healpix_pyramid(
     is_nested = bool(kwargs.get("nest", True))
     if is_nested:
         current = finest
+        current_weights: dict[str, xr.DataArray] | None = {
+            str(name): xr.where(np.isfinite(var), 1.0, 0.0)
+            for name, var in current.data_vars.items()
+            if "cell" in var.dims
+        }
         for level in range(max_level - 1, min_level - 1, -1):
-            current = coarsen_healpix(
+            current, current_weights = cast(
+                tuple[xr.Dataset, dict[str, xr.DataArray]],
+                coarsen_healpix(
                 current,
                 level,
                 coarsen_mode=coarsen_mode,
                 min_valid_fraction=min_valid_fraction,
+                child_weights=current_weights,
+                return_weights=True,
+                ),
             )
             pyramid[level] = current
         return pyramid

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -77,50 +77,71 @@ class TestCoarsenArray:
 
     def test_all_valid(self) -> None:
         data = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]])
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         np.testing.assert_allclose(result, [[2.5, 6.5]])
+        np.testing.assert_allclose(weights, [[1.0, 1.0]])
 
     def test_below_threshold_becomes_nan(self) -> None:
         """1 of 4 valid children (25%) is below the 50% threshold."""
         data = np.array([[1.0, np.nan, np.nan, np.nan, 5.0, 6.0, 7.0, 8.0]])
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         assert np.isnan(result[0, 0]), "1/4 valid should be NaN"
+        assert weights[0, 0] == 0.0
         np.testing.assert_allclose(result[0, 1], 6.5)
+        np.testing.assert_allclose(weights[0, 1], 1.0)
 
     def test_at_threshold_is_valid(self) -> None:
         """2 of 4 valid children (50%) meets the 50% threshold."""
         data = np.array([[1.0, 2.0, np.nan, np.nan]])
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         np.testing.assert_allclose(result[0, 0], 1.5)
+        np.testing.assert_allclose(weights[0, 0], 0.5)
 
     def test_all_nan_becomes_nan(self) -> None:
         data = np.full((1, 4), np.nan)
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         assert np.isnan(result[0, 0])
+        assert weights[0, 0] == 0.0
 
     def test_siberian_lake_killed(self) -> None:
         """A single valid pixel among 3 NaN siblings must not survive."""
         data = np.full((1, 4), np.nan)
         data[0, 2] = 15.0
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         assert np.isnan(result[0, 0])
+        assert weights[0, 0] == 0.0
 
     def test_batch_dims_preserved(self) -> None:
         data = np.ones((3, 5, 16))
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.5)
         assert result.shape == (3, 5, 4)
+        assert weights.shape == (3, 5, 4)
 
     def test_custom_threshold(self) -> None:
         """With threshold 0.25, 1 of 4 valid should survive."""
         data = np.array([[7.0, np.nan, np.nan, np.nan]])
-        result = _coarsen_array(data, factor=4, min_valid_fraction=0.25)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=0.25)
         np.testing.assert_allclose(result[0, 0], 7.0)
+        np.testing.assert_allclose(weights[0, 0], 0.25)
 
     def test_strict_threshold(self) -> None:
         """With threshold 1.0, any NaN child kills the parent."""
         data = np.array([[1.0, 2.0, 3.0, np.nan]])
-        result = _coarsen_array(data, factor=4, min_valid_fraction=1.0)
+        result, weights = _coarsen_array(data, factor=4, min_valid_fraction=1.0)
         assert np.isnan(result[0, 0])
+        assert weights[0, 0] == 0.0
+
+    def test_weighted_children_preserve_partial_coverage(self) -> None:
+        data = np.array([[0.0, 100.0, np.nan, np.nan]])
+        weights = np.array([[1.0, 0.25, 0.0, 0.0]])
+        result, parent_weights = _coarsen_array(
+            data,
+            factor=4,
+            min_valid_fraction=0.25,
+            weights=weights,
+        )
+        np.testing.assert_allclose(result[0, 0], 20.0)
+        np.testing.assert_allclose(parent_weights[0, 0], 0.3125)
 
 
 class TestCoarsenArrayMode:
@@ -336,14 +357,17 @@ class TestPyramidBuilders:
         monkeypatch.setattr(
             helpers,
             "coarsen_healpix",
-            lambda ds, level, **kwargs: xr.Dataset(
-                {"t": (("cell",), np.zeros(12 * (4**level)))},
-                attrs=ds.attrs
-                | {
-                    "healpix_level": level,
-                    "healpix_nside": 2**level,
-                    "healpix_order": "nested",
-                },
+            lambda ds, level, **kwargs: (
+                xr.Dataset(
+                    {"t": (("cell",), np.zeros(12 * (4**level)))},
+                    attrs=ds.attrs
+                    | {
+                        "healpix_level": level,
+                        "healpix_nside": 2**level,
+                        "healpix_order": "nested",
+                    },
+                ),
+                {"t": xr.DataArray(np.ones(12 * (4**level)), dims=["cell"])},
             ),
         )
         pyramid = create_healpix_pyramid(regular_ds, max_level=3, min_level=1)
@@ -411,10 +435,10 @@ class TestPyramidBuilders:
 
         def fake_coarsen(
             ds: xr.Dataset, level: int, **kwargs: Any
-        ) -> xr.Dataset:
+        ) -> tuple[xr.Dataset, dict[str, xr.DataArray]]:
             coarsen_calls.append(kwargs)
             npix = 12 * (4**level)
-            return xr.Dataset(
+            out = xr.Dataset(
                 {"t": (("cell",), np.zeros(npix))},
                 attrs=ds.attrs
                 | {
@@ -423,6 +447,7 @@ class TestPyramidBuilders:
                     "healpix_order": "nested",
                 },
             )
+            return out, {"t": xr.DataArray(np.ones(npix), dims=["cell"])}
 
         monkeypatch.setattr(helpers, "regrid_to_healpix", fake_regrid)
         monkeypatch.setattr(helpers, "coarsen_healpix", fake_coarsen)
@@ -437,6 +462,126 @@ class TestPyramidBuilders:
         for call in coarsen_calls:
             assert call["coarsen_mode"] == "mode"
             assert call["min_valid_fraction"] == 0.75
+
+    def test_create_healpix_pyramid_preserves_partial_coverage(
+        self, regular_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            helpers,
+            "_healpix_coords",
+            lambda level, nest: (
+                np.zeros(12 * (4**level), dtype=np.float64),
+                np.zeros(12 * (4**level), dtype=np.float64),
+            ),
+        )
+
+        def fake_regrid(ds: xr.Dataset, level: int, **kwargs: Any) -> xr.Dataset:
+            del kwargs
+            npix = 12 * (4**level)
+            pattern = np.array(
+                [0.0, 0.0, 0.0, 0.0, 100.0, np.nan, np.nan, np.nan]
+                + [np.nan] * 8,
+                dtype=np.float64,
+            )
+            tiled = np.tile(pattern, npix // 16)
+            return xr.Dataset(
+                {"t": (("cell",), tiled)},
+                coords={"cell": np.arange(npix, dtype=np.int64)},
+                attrs=ds.attrs
+                | {
+                    "healpix_nside": 2**level,
+                    "healpix_level": level,
+                    "healpix_order": "nested",
+                },
+            )
+
+        monkeypatch.setattr(helpers, "regrid_to_healpix", fake_regrid)
+
+        pyramid = create_healpix_pyramid(
+            regular_ds,
+            max_level=2,
+            min_level=0,
+            min_valid_fraction=0.25,
+        )
+        np.testing.assert_allclose(pyramid[0]["t"].values, 20.0)
+
+    def test_global_cell_mean_matches_all_levels_mixed_child_counts(
+        self, regular_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            helpers,
+            "_healpix_coords",
+            lambda level, nest: (
+                np.zeros(12 * (4**level), dtype=np.float64),
+                np.zeros(12 * (4**level), dtype=np.float64),
+            ),
+        )
+        level = 3
+        npix = 12 * (4**level)
+
+        # Mixed coverage pattern by parent (2, 3, 4, 4 valid children):
+        #  - [0, 100, NaN, NaN]       -> 2 valid
+        #  - [0, 30, 70, NaN]         -> 3 valid
+        #  - [0, 10, 10, 20]          -> 4 valid
+        #  - [20, 20, 20, 20]         -> 4 valid
+        # Repeating this 16-cell block ensures every coarsening block sees
+        # the same coverage mixture.
+        pattern16 = np.array(
+            [
+                0.0,
+                100.0,
+                np.nan,
+                np.nan,
+                0.0,
+                30.0,
+                70.0,
+                np.nan,
+                0.0,
+                10.0,
+                10.0,
+                20.0,
+                20.0,
+                20.0,
+                20.0,
+                20.0,
+            ],
+            dtype=np.float64,
+        )
+        finest_values = np.tile(pattern16, npix // 16)
+        current = xr.Dataset(
+            {"t": (("cell",), finest_values)},
+            coords={"cell": np.arange(npix, dtype=np.int64)},
+            attrs=regular_ds.attrs
+            | {
+                "healpix_nside": 2**level,
+                "healpix_level": level,
+                "healpix_order": "nested",
+            },
+        )
+
+        pyramid: dict[int, xr.Dataset] = {level: current}
+        weight_pyramid: dict[int, xr.DataArray] = {
+            level: xr.where(np.isfinite(current["t"]), 1.0, 0.0)
+        }
+        current_weights: dict[str, xr.DataArray] = {"t": weight_pyramid[level]}
+
+        for target_level in range(level - 1, -1, -1):
+            current, current_weights = helpers.coarsen_healpix(
+                current,
+                target_level,
+                min_valid_fraction=0.00001,
+                child_weights=current_weights,
+                return_weights=True,
+            )
+            pyramid[target_level] = current
+            weight_pyramid[target_level] = current_weights["t"]
+
+        level_means = {
+            lev: float(pyramid[lev]["t"].mean("cell").values) for lev in pyramid
+        }
+        reference = level_means[level]
+        for mean_value in level_means.values():
+            np.testing.assert_allclose(mean_value, reference)
 
 
 class TestSavePyramidToS3:


### PR DESCRIPTION
Propagate weights across the healpix pyramid when coarsening to take into account smaller cell coverages due to NaNs.

This is in a draft state and was fully coded by codex. And kind of collides with the idea to set NaN for parent cells because it enables a method to set a value for parent if only one child is available. 

In case this is allowed, which should be for `min_valid_fraction=0.00001` , mean over dimension `cell` should be the same across the pyramid. This should be tested with `test_global_cell_mean_matches_all_levels_mixed_child_counts`. 