### PR TITLE
feat: Embed Freva Data Browser in Waterpark docs

### DIFF
--- a/docs/assets/databrowser-loader.js
+++ b/docs/assets/databrowser-loader.js
@@ -1,0 +1,203 @@
+/*
+ * Freva Data Browser host loader.
+  * Globally registered via `extra_javascript`, but every action is gated on the
+  * presence of #databrowser-mount
+ */
+(function () {
+  "use strict";
+
+  // Module-scoped so we survive Material's instant-nav re-runs.
+  var handle = null;
+  var mountedEl = null;
+  var booting = false;
+  var schemeObserver = null;
+
+  // helpers
+  function parseConfigModule(mod) {
+    // Support `export default {...}` and a named `config` export.
+    if (!mod) return {};
+    if (mod.default && typeof mod.default === "object") return mod.default;
+    if (mod.config && typeof mod.config === "object") return mod.config;
+    return {};
+  }
+
+  function pickMount(mod) {
+    // The package exposes both a named and a default `mountDataBrowser`.
+    return (mod && mod.mountDataBrowser) || (mod && mod.default) || null;
+  }
+
+  // Dynamic import() can reject on a transient network hiccup (a reset chunk, a
+  // flaky dev server). The widget is bundled into ONE file, so this is now a
+  // single request
+  function importWithRetry(url, attempts) {
+    attempts = attempts || 3;
+    return import(/* @vite-ignore */ url).catch(function (err) {
+      if (attempts <= 1) throw err;
+      return new Promise(function (resolve) {
+        setTimeout(resolve, 250);
+      }).then(function () {
+        return importWithRetry(url, attempts - 1);
+      });
+    });
+  }
+
+  // Waterpark's Material palette: scheme "slate" = dark, "default" = light.
+  function currentMode() {
+    var scheme =
+      document.body.getAttribute("data-md-color-scheme") ||
+      document.documentElement.getAttribute("data-md-color-scheme") ||
+      "default";
+    return scheme === "slate" ? "night" : "day";
+  }
+
+  // Move the mount so it is NOT a descendant of `.md-typeset`, so Material's
+  // typeset element rules (h1/kbd/pre/line-height) can't bleed into the widget's
+  // px-based, low-specificity styling.
+  function relocateOutOfTypeset(mount) {
+    if (mount.getAttribute("data-relocated") === "1") return;
+    var typeset = mount.closest(".md-typeset");
+    if (!typeset) return;
+    var host =
+      typeset.closest(".md-content") ||
+      document.querySelector(".md-main__inner") ||
+      document.querySelector(".md-main") ||
+      document.body;
+    host.appendChild(mount);
+    mount.setAttribute("data-relocated", "1");
+  }
+
+  function syncTheme() {
+    if (handle) {
+      try {
+        handle.setTheme(currentMode());
+      } catch (e) {
+        /* noop */
+      }
+    }
+  }
+
+  function watchScheme() {
+    if (schemeObserver || !window.MutationObserver) return;
+    schemeObserver = new MutationObserver(syncTheme);
+    // Material sets data-md-color-scheme on <body>
+    schemeObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-md-color-scheme"],
+    });
+    schemeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-md-color-scheme"],
+    });
+  }
+
+  function teardown() {
+    if (schemeObserver) {
+      schemeObserver.disconnect();
+      schemeObserver = null;
+    }
+    if (handle) {
+      try {
+        handle.destroy();
+      } catch (e) {
+        /* noop — never let teardown break navigation */
+      }
+      handle = null;
+    }
+    mountedEl = null;
+    document.body.classList.remove("waterpark-databrowser-page");
+  }
+
+  // boot
+  async function boot() {
+    var mount = document.getElementById("databrowser-mount");
+
+    if (!mount) {
+      teardown();
+      return;
+    }
+
+    // Already mounted into this exact node
+    if (handle && mountedEl === mount) return;
+
+    // The node changed
+    if (handle && mountedEl !== mount) teardown();
+
+    if (booting) return;
+    booting = true;
+
+    document.body.classList.add("waterpark-databrowser-page");
+
+    // Escape Material's typeset wrapper BEFORE mounting
+    relocateOutOfTypeset(mount);
+
+    var entry = mount.getAttribute("data-databrowser-entry");
+    var configUrl = mount.getAttribute("data-databrowser-config");
+    var inspectorUrl = mount.getAttribute("data-databrowser-inspector");
+    if (!entry) {
+      booting = false;
+      return;
+    }
+
+    try {
+      var results = await Promise.all([
+        importWithRetry(entry, 3),
+        configUrl
+          ? importWithRetry(configUrl, 3).catch(function () {
+              return {};
+            })
+          : Promise.resolve({}),
+      ]);
+
+      // important re-check: the user may have navigated away while we were importing.
+      var stillHere = document.getElementById("databrowser-mount");
+      if (!stillHere || stillHere !== mount) {
+        booting = false;
+        boot();
+        return;
+      }
+
+      var mountFn = pickMount(results[0]);
+      if (typeof mountFn !== "function") {
+        throw new Error("mountDataBrowser export not found in " + entry);
+      }
+
+      // Merge host-provided runtime bits onto the static config
+      var config = parseConfigModule(results[1]);
+      // Self-hosted inspector
+      if (inspectorUrl) config.inspectorUrl = inspectorUrl;
+      // Open in Waterpark's current light/dark mode from the first paint
+      config.theme = config.theme || {};
+      config.theme.mode = currentMode();
+
+      handle = mountFn(mount, config);
+      mountedEl = mount;
+
+      // Keep following Waterpark's palette toggle for the rest of the visit.
+      syncTheme();
+      watchScheme();
+    } catch (e) {
+      // Surface a message instead of a blank page.
+      if (mount && !mount.firstChild) {
+        var msg = document.createElement("div");
+        msg.className = "waterpark-databrowser-error";
+        msg.textContent =
+          "The Data Browser could not be loaded. Please try again later.";
+        mount.appendChild(msg);
+      }
+      if (window.console && console.error) {
+        console.error("[databrowser] mount failed:", e);
+      }
+    } finally {
+      booting = false;
+    }
+  }
+
+  // Material publishes `document$` on every navigation
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(boot);
+  } else if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/docs/assets/databrowser.config.js
+++ b/docs/assets/databrowser.config.js
@@ -1,0 +1,47 @@
+/*
+ * Freva Data Browser embed configuration.
+ *
+ * This is the single place to tune the embedded Data Browser.
+ */
+export default {
+  // Backend 
+  apiBase: "https://freva.dkrz.de/api/freva-nextgen/databrowser",
+
+  // Default metadata flavour.
+  flavour: "freva",
+
+  // Optional freva-web-parity script that maps facet VALUES to human-readable
+  // descriptions.
+  metadataScriptUrl: "",
+
+  // Public, read-only demo
+  authEnabled: false,
+  enableHeavyOps: false,
+
+  // Mirror the active query (flavour + facets + time + bbox) into the page URL
+  // so a link reproduces the exact view, and read it back on load. Safe here
+  syncUrl: true,
+
+  // Scope: Waterpark-only "hosted filtered instance"
+  baseFilters: { project: "waterpark" },
+
+  // Brand
+  brand: {
+    title: "Freva Data-Browser",
+    mark: "≈",
+    description: "Search the HEALPix data hub via the freva-nextgen API.",
+  },
+
+
+  // Theme: match the Waterpark dominant colour
+  // The widget's OWN day/night toggle is disabled
+  features: {
+    themeToggle: false,
+  },
+  theme: {
+    both: {
+      accent: "var(--md-primary-fg-color, #009688)",
+      "accent-2": "var(--md-primary-fg-color--dark, #00695c)",
+    },
+  },
+};

--- a/docs/assets/databrowser.css
+++ b/docs/assets/databrowser.css
@@ -1,0 +1,54 @@
+/*
+ * Freva Data Browser embed; host-side layout only.
+ */
+
+/* Full-bleed: drop Material's content max-width / centering on this page. */
+body.waterpark-databrowser-page .md-main__inner,
+body.waterpark-databrowser-page .md-content,
+body.waterpark-databrowser-page .md-content__inner {
+  max-width: none;
+  margin: 0;
+}
+
+body.waterpark-databrowser-page .md-content__inner {
+  padding: 0;
+  min-height: 0;
+}
+body.waterpark-databrowser-page .md-content__inner > h1:first-child {
+  display: none;
+}
+body.waterpark-databrowser-page .md-content__inner::before {
+  display: none;
+}
+
+/* 2. Mount sizing */
+.waterpark-databrowser-wrapper {
+  width: 100%;
+}
+body.waterpark-databrowser-page #databrowser-mount {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: calc(100vh - var(--md-header-height, 48px));
+  min-height: 680px;
+  overflow: hidden;
+}
+
+/* Accent to Waterpark dominant colour (teal `--md-primary-fg-color`). */
+body.waterpark-databrowser-page .freva-db {
+  --accent: var(--md-primary-fg-color, #009688);
+  --accent-2: var(--md-primary-fg-color--dark, #00695c);
+}
+
+/* Loader error fallback */
+.waterpark-databrowser-error {
+  margin: 2rem auto;
+  max-width: 40rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--md-default-fg-color--lightest, #ddd);
+  border-left: 4px solid var(--md-primary-fg-color, #009688);
+  border-radius: 6px;
+  color: var(--md-default-fg-color, #333);
+  background: var(--md-default-bg-color, #fff);
+  font-size: 0.8rem;
+}

--- a/docs/scripts/build_databrowser_docs.py
+++ b/docs/scripts/build_databrowser_docs.py
@@ -1,0 +1,213 @@
+"""
+Fetch, vendor and embed the Freva Data Browser into the Waterpark (data) docs.
+
+The host loader (``docs/assets/databrowser-loader.js``) calls ``mountDataBrowser``
+with the settings in ``docs/assets/databrowser.config.js``.
+
+IMPORTANT: Runtime settings live in ``docs/assets/databrowser.config.js``.
+Env overrides:
+  ``DATABROWSER_VERSION``            npm version/dist-tag (default ``latest``)
+  ``DATABROWSER_PACKAGE``            package name (default ``@freva-org/databrowser``)
+  ``DATABROWSER_INSPECTOR_VERSION``  inspector version/tag (default ``latest``)
+  ``DATABROWSER_INSPECTOR_PACKAGE``  inspector pkg (default ``@freva-org/data-inspector``)
+  ``WATERPARK_BASE_PATH``            URL base, e.g. ``/`` or ``/grid-doctor``
+  ``GRID_DOCTOR_ROOT``              repo root override
+"""
+from __future__ import annotations
+
+import html
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Locations
+SCRIPT_DIR = Path(__file__).resolve().parent
+ASSETS_DIR = SCRIPT_DIR.parent / "assets"
+REPO_ROOT = Path(os.environ.get("GRID_DOCTOR_ROOT", SCRIPT_DIR.parents[1])).resolve()
+
+CONFIG_FILE = ASSETS_DIR / "databrowser.config.js"
+
+# Isolated install dir
+INSTALL_DIR = REPO_ROOT / ".build" / "databrowser-src"
+BUILD_DATA = REPO_ROOT / ".build" / "data"
+
+PACKAGE = os.environ.get("DATABROWSER_PACKAGE", "@freva-org/databrowser").strip()
+# The lazy file-inspector web component
+INSPECTOR_PACKAGE = os.environ.get(
+    "DATABROWSER_INSPECTOR_PACKAGE", "@freva-org/data-inspector").strip()
+# latest always
+VERSION = os.environ.get("DATABROWSER_VERSION", "latest").strip() or "latest"
+INSPECTOR_VERSION = os.environ.get(
+    "DATABROWSER_INSPECTOR_VERSION", "latest").strip() or "latest"
+
+
+# URL layout
+def normalize_base_path(value: str | None) -> str:
+    """'' for root, else a single leading slash and no trailing slash."""
+    value = (value or "/").strip()
+    return "" if value in {"", "/"} else "/" + value.strip("/")
+
+
+BASE_PATH = normalize_base_path(os.environ.get("WATERPARK_BASE_PATH", "/"))
+ASSET_URL = f"{BASE_PATH}/databrowser"
+INSPECTOR_URL = f"{BASE_PATH}/databrowser-inspector"
+CONFIG_URL = f"{BASE_PATH}/assets/databrowser.config.js"
+
+
+def _run(cmd: list[str], cwd: Path | None = None, env: dict | None = None,
+         capture: bool = False) -> str:
+    print(f"[databrowser] $ {' '.join(cmd)}")
+    if capture:
+        out = subprocess.run(cmd, cwd=cwd, env=env, check=True,
+                             capture_output=True, text=True).stdout.strip()
+        print(f"[databrowser]   -> {out}")
+        return out
+    subprocess.run(cmd, cwd=cwd, env=env, check=True)
+    return ""
+
+
+def install_packages() -> dict[str, Path]:
+    """
+    Install ``PACKAGE`` and ``INSPECTOR_PACKAGE`` into
+    an isolated dir
+    """
+    npm = shutil.which("npm")
+    if not npm:
+        sys.exit("[databrowser] npm not found; the docs build needs Node.js.")
+
+    if INSTALL_DIR.exists():
+        shutil.rmtree(INSTALL_DIR)
+    INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+    # A minimal private package.json keeps npm from walking up to a parent
+    # manifest and avoids the "no lockfile in CI" refusal path.
+    (INSTALL_DIR / "package.json").write_text(json.dumps(
+        {"name": "waterpark-databrowser-vendor", "private": True,
+         "version": "0.0.0"}, indent=2))
+
+    specs = [f"{PACKAGE}@{VERSION}", f"{INSPECTOR_PACKAGE}@{INSPECTOR_VERSION}"]
+    print(f"[databrowser] installing {', '.join(specs)} "
+          f"(latest-always unless pinned)")
+    # esbuild bundles the browser's multi-file ESM tree into ONE self-contained
+    # file 
+    _run([npm, "install", *specs, "esbuild@0.24.2",
+          "--no-audit", "--no-fund", "--silent"], cwd=INSTALL_DIR)
+
+    dists: dict[str, Path] = {}
+    for name in (PACKAGE, INSPECTOR_PACKAGE):
+        pkg_dir = INSTALL_DIR / "node_modules" / name
+        dist = pkg_dir / "dist"
+        if not dist.exists():
+            sys.exit(f"[databrowser] installed package has no dist/: {dist}")
+        resolved = json.loads((pkg_dir / "package.json").read_text()).get("version")
+        print(f"[databrowser] resolved {name} -> {resolved}")
+        dists[name] = dist
+    return dists
+
+
+def entry_file(dist: Path) -> str:
+    """
+    The ESM entry, taken from the package's own ``exports``/``module``/``main``.
+    Both packages publish a browser-ready ESM entry
+    """
+    manifest = json.loads((dist.parent / "package.json").read_text())
+    raw = (
+        (manifest.get("exports", {}).get(".", {}) or {}).get("import")
+        or manifest.get("module")
+        or manifest.get("main")
+        or "./dist/index.js"
+    )
+    return Path(raw).name
+
+
+BROWSER_BUNDLE = "index.js" 
+
+
+def bundle_browser(dist: Path) -> str:
+    """
+    Bundle the browser's multi-file ESM tree into ONE self-contained file at
+    .build/data/databrowser/index.js
+    """
+    npm = shutil.which("npm")
+    esbuild = INSTALL_DIR / "node_modules" / ".bin" / "esbuild"
+    if not esbuild.exists():
+        sys.exit(f"[databrowser] esbuild not found at {esbuild}")
+
+    target_dir = BUILD_DATA / "databrowser"
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    out = target_dir / BROWSER_BUNDLE
+
+    _run([str(esbuild), str(dist / "index.js"),
+          "--bundle", "--format=esm", "--minify",
+          "--legal-comments=none", f"--outfile={out}"])
+    size_kb = out.stat().st_size / 1024
+    print(f"[databrowser] bundled browser -> {out} ({size_kb:.0f} KB, 1 request)")
+    return BROWSER_BUNDLE
+
+
+def copy_single(dist: Path, entry: str, subdir: str) -> None:
+    """Copy a single already-bundled entry file into .build/data/<subdir>/."""
+    target = BUILD_DATA / subdir
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(dist / entry, target / entry)
+    print(f"[databrowser] copied {entry} -> {target}")
+
+
+def render_page(entry_js: str, inspector_mjs: str) -> str:
+    """Emit the mkdocs page: a sized mount div; the host loader does the rest."""
+    entry_url = html.escape(f"{ASSET_URL}/{entry_js}", quote=True)
+    inspector_url = html.escape(f"{INSPECTOR_URL}/{inspector_mjs}", quote=True)
+    config_url = html.escape(CONFIG_URL, quote=True)
+    return f"""---
+title: Data Browser
+hide:
+  - navigation
+  - toc
+---
+
+<!-- AUTO-GENERATED by docs/scripts/build_databrowser_docs.py. Do not edit;
+     settings live in docs/assets/databrowser.config.js. -->
+
+<div class="waterpark-databrowser-wrapper">
+  <div id="databrowser-mount"
+       data-databrowser-entry="{entry_url}"
+       data-databrowser-inspector="{inspector_url}"
+       data-databrowser-config="{config_url}"></div>
+</div>
+"""
+
+
+def main() -> None:
+    target = sys.argv[1] if len(sys.argv) > 1 else "tech"
+    if target != "data":
+        print(f"[databrowser] target={target!r}: nothing to do.")
+        return
+
+    if not BUILD_DATA.exists():
+        sys.exit(
+            f"[databrowser] .build/data missing ({BUILD_DATA}). Run via tox "
+            f"after docs-prep, or set GRID_DOCTOR_ROOT. Repo root: {REPO_ROOT}."
+        )
+
+    if not CONFIG_FILE.exists():
+        print(f"[databrowser] ::warning:: {CONFIG_FILE.name} not found; "
+              f"the loader will fall back to built-in defaults.")
+
+    dists = install_packages()
+    entry_js = bundle_browser(dists[PACKAGE])
+    inspector_mjs = entry_file(dists[INSPECTOR_PACKAGE])
+    copy_single(dists[INSPECTOR_PACKAGE], inspector_mjs, "databrowser-inspector")
+    (BUILD_DATA / "databrowser.md").write_text(
+        render_page(entry_js, inspector_mjs))
+    print(f"[databrowser] embedded OK (entry={entry_js}, "
+          f"inspector={inspector_mjs})")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -82,9 +82,11 @@ extra_css:
   - assets/styles.css
   - assets/waterpark-tree.css
   - assets/stac-browser.css
+  - assets/databrowser.css
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - assets/stac-browser-loader.js
+  - assets/databrowser-loader.js
   - assets/waterpark-tree.js
   - assets/waterpark-inspector.js

--- a/mkdocs.data.yml
+++ b/mkdocs.data.yml
@@ -20,6 +20,7 @@ extra:
 
 nav:
   - Overview: index.md
+  - Data Browser: databrowser.md
   - STAC Browser: stac-browser.md
   - Storage Concepts:
       - HEALPix in Zarr on S3: storage_concepts/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ deps =
     codespell
 commands =
     python docs/scripts/build_stac_browser_docs.py {posargs:tech}
+    python docs/scripts/build_databrowser_docs.py {posargs:tech}
     codespell {posargs: --quiet-level=2} docs
     mkdocs build --strict -f mkdocs.{posargs:tech}.yml
 
@@ -226,6 +227,7 @@ commands_pre =
     {[docs-prep]serve}
 commands =
     python docs/scripts/build_stac_browser_docs.py {posargs:tech}
+    python docs/scripts/build_databrowser_docs.py {posargs:tech}
     codespell --quiet-level=2 docs
     mkdocs serve -f mkdocs.{posargs:tech}.yml --strict -a localhost:8000 --watch docs
 


### PR DESCRIPTION
In this PR we are going to Embed the new freva-databrowser into the Waterpark docs as a new Data Browser page, alongside other tabs. It's scoped to `project=waterpark`, which means, it's still using the freva.dkrz.de as the backend restAPI, but always the `?project=waterpark` is enabled on each query.