### PR TITLE
change databrowser: switch the default flavour to waterpark

### DIFF
--- a/docs/assets/databrowser.config.js
+++ b/docs/assets/databrowser.config.js
@@ -8,7 +8,7 @@ export default {
   apiBase: "https://freva.dkrz.de/api/freva-nextgen/databrowser",
 
   // Default metadata flavour.
-  flavour: "freva",
+  flavour: "waterpark",
 
   // Optional freva-web-parity script that maps facet VALUES to human-readable
   // descriptions.


### PR DESCRIPTION
We created a global flavour via freva.dkrz.de namely `waterpark` which only map `level_type` facet to `level` and via this PR we are going to set it as default. Since we have the update option in flavours, we can simply change the facet mappings in the future.