### PR TITLE
fix-stacbrowse: canonicalize root links so up button lands on internal landing page

### DIFF
--- a/docs/assets/stac-browser.config.js
+++ b/docs/assets/stac-browser.config.js
@@ -1,5 +1,5 @@
 export default {
-    catalogUrl: "https://freva.dkrz.de/api/freva-nextgen/stacapi/product/?visible_collections=cmip6,dyamond,eerie,icdc,icon-dream,nextgems,obs,palmod,reanalysis",
+    catalogUrl: "https://freva.dkrz.de/api/freva-nextgen/stacapi/product/?visible_collections=cmip6,dyamond,eerie,icdc,icon-dream,nextgems,obs,palmod,reanalysis-healpix",
 
     // Header
     catalogTitle: "STAC Browser",
@@ -13,6 +13,21 @@ export default {
 
     // Landing content (root catalog only)
     preprocessSTAC(stac, state) {
+        // Canonicalize root-equivalent links to catalogUrl so "up" lands on "/" not /external/...
+        const catalog = (() => { try { return new URL(state.catalogUrl); } catch { return null; } })();
+        if (catalog && Array.isArray(stac.links)) {
+          const stripSlash = p => p.replace(/\/+$/, "");
+          const rootPath = stripSlash(catalog.pathname);
+          for (const link of stac.links) {
+            if (!link || typeof link.href !== "string") continue;
+            let u;
+            try { u = new URL(link.href, state.catalogUrl); } catch { continue; }
+            if (u.host === catalog.host && stripSlash(u.pathname) === rootPath) {
+              link.href = state.catalogUrl;
+            }
+          }
+        }
+
         const base = u =>
           (u || "")
             .split("?")[0]


### PR DESCRIPTION
Clicking the up button from a collection level back to the landing page produced `#/external/freva.dkrz.de/api/blahblah`, which errored out and left the user stuck with no way to keep browsing. Going the other way, from an item down to a collection level worked fine.
This is a bug in STAC-Browser and should be fixed upstream. For now, to keep prod healthy, we patch it in place; once we have time, we'll dig in and propose a PR upstream.
One more note: in regiklim-dev we already had a `reanalysis` product, so we had to rename the new one to `reanalysis-healpix`. Keeping both under the same name is fine in the new data-browser, but not in STAC-Browser: because for waterpark we switched the axis from project to product, the REST API groups all `reanalysis` data under a single collection, and the user ends up seeing the posix nc ERA5 files in waterpark.