### PR TITLE
CF Healpix Attributes

### DIFF
--- a/docs/shared/high-level-access.md
+++ b/docs/shared/high-level-access.md
@@ -5,15 +5,15 @@ catchment) at very high HEALPix levels (16 is roughly 100 m, 20 roughly
 6 m cells).  These stores look different from the global pyramids in
 two ways, and both change how you load them:
 
-1. **No coordinate arrays.**  The global cell dimension at level 16 has
+1. **No coordinate arrays.**  The global `healpix_index` (commonly called `cell`) dimension at level 16 has
    about 5.2 × 10¹⁰ entries; materialised `latitude`/`longitude` arrays
    would cost hundreds of gigabytes while carrying no information,
-   because HEALPix coordinates are a pure function of the cell index.
+   because HEALPix coordinates are a pure function of the index.
    These stores carry only the `crs` variable and the `healpix_*`
    attributes (`grid_doctor_implicit_coords = 1` marks them), and
    coordinates are computed on the fly for whatever cells you actually
    read.
-2. **All access is region-driven.**  Nobody loads the full cell
+2. **All access is region-driven.**  Nobody loads the full `healpix_index`
    dimension, the same way nobody downloads a complete XYZ tile set.
    You select a region; the selection is small by construction.
 
@@ -103,7 +103,7 @@ def merge_ranges(parents, shift):
 
 ranges = merge_ranges(parents, shift)
 region = xr.concat(
-    [ds.isel(cell=slice(a, b)) for a, b in ranges], dim="cell"
+    [ds.isel(healpix_index=slice(a, b)) for a, b in ranges], dim="healpix_index"
 )
 ```
 
@@ -120,20 +120,20 @@ cell_ids = np.concatenate(
 lon_c, lat_c = nested.healpix_to_lonlat(cell_ids, level)
 
 region = region.assign_coords(
-    cell=("cell", cell_ids),
-    longitude=("cell", lon_c),
-    latitude=("cell", lat_c),
+    healpix_index=("healpix_index", cell_ids),
+    longitude=("healpix_index", lon_c),
+    latitude=("healpix_index", lat_c),
 )
 
 inside = (
     (lon_c >= lon_min) & (lon_c <= lon_max)
     & (lat_c >= lat_min) & (lat_c <= lat_max)
 )
-berlin = region.isel(cell=np.flatnonzero(inside)).load()
+berlin = region.isel(healpix_index=np.flatnonzero(inside)).load()
 ```
 
 `berlin` is now a small, fully loaded dataset with per-cell
-coordinates and the global HEALPix indices in `berlin["cell"]`:
+coordinates and the global HEALPix indices in `berlin["healpix_index"]`:
 
 ```python
 berlin["t2m"].mean()
@@ -155,7 +155,7 @@ def gc_distance_deg(lon, lat, lon0, lat0):
     return np.degrees(2 * np.arcsin(np.sqrt(s)))
 
 inside = gc_distance_deg(lon_c, lat_c, 13.41, 52.52) <= 0.05
-station = region.isel(cell=np.flatnonzero(inside)).load()
+station = region.isel(healpix_index=np.flatnonzero(inside)).load()
 ```
 
 ### Why this is fast
@@ -195,9 +195,9 @@ place your high-resolution selection onto, say, an ERA5 pyramid level,
 reuse the slice expansion from above at the coarser level:
 
 ```python
-parents_l9 = np.unique(berlin["cell"].values >> (2 * (16 - 9)))
+parents_l9 = np.unique(berlin["healpix_index"].values >> (2 * (16 - 9)))
 era5_region = era5_level9.isel(
-    cell=np.concatenate([np.arange(p, p + 1) for p in parents_l9])
+    healpix_index=np.concatenate([np.arange(p, p + 1) for p in parents_l9])
 )
 ```
 

--- a/docs/technical/recipes/regional.md
+++ b/docs/technical/recipes/regional.md
@@ -137,7 +137,7 @@ NaN-aware mean** — no latitude weighting, no domain mask file:
 ```python
 import xarray as xr
 
-ds9 = xr.open_zarr("s3://.../cordex-eur11-tas.zarr/level_9.zarr", chunks=None)
+ds9 = xr.open_zarr("s3://.../cordex-eur11-tas.zarr/level_9.zarr", chunks=None).rename({"cell":"healpix_index"})
 domain_mean = ds9["tas"].mean("cell", skipna=True)   # area-weighted by construction
 ```
 

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -4,11 +4,13 @@ Provides abstractions to convert remapping terms (level, order, grid type)
 to the respective CF vocabolary.
 """
 
-from enum import Enum
 from typing import Mapping
+from typing import get_args as get_type_args
+
+from grid_doctor.types import HealpixIndexScheme
 
 
-class CFKey(Enum):
+class CFKey:
     """Supported CF attribute keys."""
 
     MAPPING = "grid_mapping_name"  # - "healpix"
@@ -16,10 +18,28 @@ class CFKey(Enum):
     LEVEL = "refinement_level"  # - The HEALPix refinement level
 
 
-def healpix_cf_attrs(level: int, scheme: str) -> Mapping[CFKey, str]:
+def _healpix_cf_attrs(
+    scheme: str | HealpixIndexScheme, level: int | None = None
+) -> Mapping[str, str]:
     """Given a level and an scheme, returns a dictionary with the values mapped as attributes."""
-    if scheme not in {"nested", "ring", "nuniq", "zuniq"}:
-        raise ValueError("Cannot attach unsupported scheme")
+    _schemes: tuple[str] = get_type_args(HealpixIndexScheme)
+    if scheme not in _schemes:
+        raise ValueError(
+            f'Cannot attach unsupported scheme "{scheme}". Supported: {_schemes}',
+        )
+
+    if scheme in {"nuniq", "zuniq"}:
+        return {
+            CFKey.MAPPING: "healpix",
+            CFKey.SCHEME: str(scheme),
+        }
+
+    # This is mandatory for nested and ring but must be omitted for *uniq
+    # https://cfconventions.org/cf-conventions/cf-conventions.html#healpix
+    if level is None:
+        raise ValueError(
+            f"Indexing scheme {scheme} requires a valid healpix refinement level."
+        )
 
     if not isinstance(level, int):
         raise ValueError(
@@ -30,7 +50,7 @@ def healpix_cf_attrs(level: int, scheme: str) -> Mapping[CFKey, str]:
         raise ValueError(f"Cannot set negative refinement level: '{level}'")
 
     return {
+        CFKey.LEVEL: str(level),
         CFKey.MAPPING: "healpix",
         CFKey.SCHEME: str(scheme),
-        CFKey.LEVEL: str(level),
     }

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -4,53 +4,118 @@ Provides abstractions to convert remapping terms (level, order, grid type)
 to the respective CF vocabulary.
 """
 
-from typing import Mapping
+import operator
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import (
+    Iterator,
+    Literal,
+    Mapping,
+    cast,
+)
 from typing import get_args as get_type_args
 
-from grid_doctor.types import HealpixIndexScheme
+from grid_doctor.types import (
+    HealpixIndexScheme,
+)
+
+_ALLOWED_SCHEMES = frozenset(get_type_args(HealpixIndexScheme))
+_LEVEL_NEEDED = frozenset(
+    {
+        "nested",
+        "ring",
+    }
+)
 
 
-class CFKey:
-    """Supported CF attribute keys."""
+@dataclass
+class CFHealpixGridAttrs:
+    """Models `healpix` grid mapping attribute according to CF conventions.
 
-    MAPPING = "grid_mapping_name"  # - "healpix"
-    SCHEME = "indexing_scheme"  # - "nested", "ring", "nuniq", or "zuniq"
-    LEVEL = "refinement_level"  # - The HEALPix refinement level
+    - grid_mapping_name is always "healpix"
+    - indexing_scheme can be one of "nested", "ring", "nuniq", "zuniq".
+    - refinement_level is a positive int, required only for "nested" or "ring" indexing_schemes.
+    """
+
+    grid_mapping_name: Literal["healpix"] = field(
+        default="healpix",
+        init=False,
+    )
+    indexing_scheme: HealpixIndexScheme
+    refinement_level: int | None = None
+
+    def __post_init__(
+        self,
+    ) -> None:
+        """Validate instantiations."""
+        if self.indexing_scheme not in _ALLOWED_SCHEMES:
+            raise ValueError(
+                f"`indexing_scheme` must be one of {sorted(_ALLOWED_SCHEMES)}, not {self.indexing_scheme!r}"
+            )
+
+        if self.indexing_scheme in _LEVEL_NEEDED:
+            # `refinement_level` is mandatory for `nested` and `ring` but must be omitted for *uniq
+            # https://cfconventions.org/cf-conventions/cf-conventions.html#healpix
+            if self.refinement_level is None:
+                raise ValueError(
+                    f"Indexing scheme {self.indexing_scheme!r} requires a `refinement_level` to be set."
+                )
+
+            try:
+                operator.index(self.refinement_level)
+            except (
+                TypeError,
+                ValueError,
+            ):
+                raise ValueError(
+                    f"Invalid `refinement_level`: '{self.refinement_level}'; Must be integer."
+                )
+
+            if self.refinement_level < 0:
+                raise ValueError(f"Cannot set negative `refinement_level`: '{self.refinement_level}'.")
+        else:
+            if self.refinement_level is not None:
+                raise ValueError(
+                    f"`refinement_level` cannot be specified when `indexing_scheme` is {self.indexing_scheme!r}."
+                )
+
+    def __iter__(
+        self,
+    ) -> Iterator[
+        tuple[
+            str,
+            str | int,
+        ]
+    ]:
+        """Iterate through class fields, skipping optionals."""
+        yield (
+            "grid_mapping_name",
+            self.grid_mapping_name,
+        )
+        yield (
+            "indexing_scheme",
+            self.indexing_scheme,
+        )
+        if self.refinement_level:
+            yield (
+                "refinement_level",
+                self.refinement_level,
+            )
 
 
 def _healpix_cf_attrs(
-    scheme: str, level: int | None = None
-) -> Mapping[str, str]:
+    scheme: str,
+    level: int | None = None,
+) -> Mapping[str, str | int]:
     """Given a level and a scheme, returns a dictionary with the values mapped as attributes."""
-    _schemes: tuple[str] = get_type_args(HealpixIndexScheme)
-    if scheme not in _schemes:
-        raise ValueError(
-            f'Cannot attach unsupported scheme "{scheme}". Supported: {_schemes}',
+    return dict(
+        CFHealpixGridAttrs(
+            indexing_scheme=cast(
+                HealpixIndexScheme,
+                scheme,
+            ),
+            refinement_level=level,
         )
-
-    if scheme in {"nuniq", "zuniq"}:
-        return {
-            CFKey.MAPPING: "healpix",
-            CFKey.SCHEME: str(scheme),
-        }
-
-    # This is mandatory for nested and ring but must be omitted for *uniq
-    # https://cfconventions.org/cf-conventions/cf-conventions.html#healpix
-    if level is None:
-        raise ValueError(
-            f"Indexing scheme {scheme} requires a valid healpix refinement level."
-        )
-
-    if not isinstance(level, int):
-        raise ValueError(
-            f"Cannot set invalid refinement level: '{level}' (must be integer)."
-        )
-
-    if level < 0:
-        raise ValueError(f"Cannot set negative refinement level: '{level}'")
-
-    return {
-        CFKey.LEVEL: str(level),
-        CFKey.MAPPING: "healpix",
-        CFKey.SCHEME: str(scheme),
-    }
+    )

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -1,7 +1,7 @@
 """High-level helpers for CF conventions.
 
 Provides abstractions to convert remapping terms (level, order, grid type)
-to the respective CF vocabolary.
+to the respective CF vocabulary.
 """
 
 from typing import Mapping
@@ -19,9 +19,9 @@ class CFKey:
 
 
 def _healpix_cf_attrs(
-    scheme: str | HealpixIndexScheme, level: int | None = None
+    scheme: str, level: int | None = None
 ) -> Mapping[str, str]:
-    """Given a level and an scheme, returns a dictionary with the values mapped as attributes."""
+    """Given a level and a scheme, returns a dictionary with the values mapped as attributes."""
     _schemes: tuple[str] = get_type_args(HealpixIndexScheme)
     if scheme not in _schemes:
         raise ValueError(

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -154,4 +154,9 @@ def healpix_grid_mapping_attrs(
     )
 
 
-__all__ = ["HealpixNested", "HealpixRing", "HealpixIndexScheme", "healpix_grid_mapping_attrs"]
+def conventions_attrs() -> dict[str, str]:
+    r"""Return a dictionary with global CF attributes - e.g. ``{"Conventions": "CF-1.13"}``."""
+    return CFConventions().to_dict()
+
+
+__all__ = ["HealpixNested", "HealpixRing", "HealpixIndexScheme", "conventions_attrs", "healpix_grid_mapping_attrs"]

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -144,3 +144,6 @@ def healpix_grid_mapping_attrs(
             refinement_level=level,
         )
     )
+
+
+__all__ = ["HealpixIndexScheme", "healpix_grid_mapping_attrs"]

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -11,6 +11,7 @@ from dataclasses import (
     field,
 )
 from typing import (
+    Final,
     Iterator,
     Literal,
     Mapping,
@@ -18,14 +19,21 @@ from typing import (
 )
 from typing import get_args as get_type_args
 
+# Types for CF healpix
+HealpixNested: Final = "nested"
+"""Healpix nested CF indexing scheme."""
+
+HealpixRing: Final = "ring"
+"""Healpix ring CF indexing scheme."""
+
 HealpixIndexScheme = Literal["nested", "ring", "zuniq", "nuniq"]
 """Allowed Healpix indexing schemes."""
 
 _ALLOWED_SCHEMES = frozenset(get_type_args(HealpixIndexScheme))
 _LEVEL_NEEDED = frozenset(
     {
-        "nested",
-        "ring",
+        HealpixNested,
+        HealpixRing,
     }
 )
 
@@ -146,4 +154,4 @@ def healpix_grid_mapping_attrs(
     )
 
 
-__all__ = ["HealpixIndexScheme", "healpix_grid_mapping_attrs"]
+__all__ = ["HealpixNested", "HealpixRing", "HealpixIndexScheme", "healpix_grid_mapping_attrs"]

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -44,7 +44,7 @@ class CFConventions:
         return asdict(self)
 
 
-@dataclass
+@dataclass(frozen=True)
 class CFHealpixGridAttrs:
     """Models `healpix` grid mapping attribute according to CF conventions.
 

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -126,6 +126,10 @@ class CFHealpixGridAttrs:
         if self.earth_radius:
             yield ("earth_radius", self.earth_radius)
 
+    def to_dict(self) -> dict[str, str | int]:
+        """Convert class instance into an equivalent dictionary."""
+        return dict(self)
+
 
 def _healpix_cf_attrs(
     scheme: str,

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -18,9 +18,8 @@ from typing import (
 )
 from typing import get_args as get_type_args
 
-from grid_doctor.types import (
-    HealpixIndexScheme,
-)
+HealpixIndexScheme = Literal["nested", "ring", "zuniq", "nuniq"]
+"""Allowed Healpix indexing schemes."""
 
 _ALLOWED_SCHEMES = frozenset(get_type_args(HealpixIndexScheme))
 _LEVEL_NEEDED = frozenset(

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -37,6 +37,7 @@ class CFHealpixGridAttrs:
     - grid_mapping_name is always "healpix"
     - indexing_scheme can be one of "nested", "ring", "nuniq", "zuniq".
     - refinement_level is a positive int, required only for "nested" or "ring" indexing_schemes.
+    - earth-radius is the optional radius of the sphere, in meters.
     """
 
     grid_mapping_name: Literal["healpix"] = field(
@@ -45,6 +46,7 @@ class CFHealpixGridAttrs:
     )
     indexing_scheme: HealpixIndexScheme
     refinement_level: int | None = None
+    earth_radius: int | None = 6371009
 
     def __post_init__(
         self,
@@ -81,6 +83,13 @@ class CFHealpixGridAttrs:
                     f"`refinement_level` cannot be specified when `indexing_scheme` is {self.indexing_scheme!r}."
                 )
 
+        # Validate earth_radius if provided
+        if self.earth_radius:
+            try:
+                operator.index(self.earth_radius)
+            except (TypeError, ValueError):
+                raise ValueError(f"Invalid `earth_radius`: {self.earth_radius!r}; Must be integer, in meters!")
+
     def __iter__(
         self,
     ) -> Iterator[
@@ -98,11 +107,14 @@ class CFHealpixGridAttrs:
             "indexing_scheme",
             self.indexing_scheme,
         )
+
         if self.refinement_level:
             yield (
                 "refinement_level",
                 self.refinement_level,
             )
+        if self.earth_radius:
+            yield ("earth_radius", self.earth_radius)
 
 
 def _healpix_cf_attrs(

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -130,7 +130,7 @@ class CFHealpixGridAttrs:
         return dict(self)
 
 
-def _healpix_cf_attrs(
+def healpix_grid_mapping_attrs(
     scheme: str,
     level: int | None = None,
 ) -> Mapping[str, str | int]:

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -1,0 +1,36 @@
+"""High-level helpers for CF conventions.
+
+Provides abstractions to convert remapping terms (level, order, grid type)
+to the respective CF vocabolary.
+"""
+
+from enum import Enum
+from typing import Mapping
+
+
+class CFKey(Enum):
+    """Supported CF attribute keys."""
+
+    MAPPING = "grid_mapping_name"  # - "healpix"
+    SCHEME = "indexing_scheme"  # - "nested", "ring", "nuniq", or "zuniq"
+    LEVEL = "refinement_level"  # - The HEALPix refinement level
+
+
+def healpix_cf_attrs(level: int, scheme: str) -> Mapping[CFKey, str]:
+    """Given a level and an scheme, returns a dictionary with the values mapped as attributes."""
+    if scheme not in {"nested", "ring", "nuniq", "zuniq"}:
+        raise ValueError("Cannot attach unsupported scheme")
+
+    if not isinstance(level, int):
+        raise ValueError(
+            f"Cannot set invalid refinement level: '{level}' (must be integer)."
+        )
+
+    if level < 0:
+        raise ValueError(f"Cannot set negative refinement level: '{level}'")
+
+    return {
+        CFKey.MAPPING: "healpix",
+        CFKey.SCHEME: str(scheme),
+        CFKey.LEVEL: str(level),
+    }

--- a/src/grid_doctor/cf.py
+++ b/src/grid_doctor/cf.py
@@ -6,6 +6,7 @@ to the respective CF vocabulary.
 
 import operator
 from dataclasses import (
+    asdict,
     dataclass,
     field,
 )
@@ -28,6 +29,19 @@ _LEVEL_NEEDED = frozenset(
         "ring",
     }
 )
+
+_CONV_VERSION = 1.13
+
+
+@dataclass(frozen=True, slots=True)
+class CFConventions:
+    """Model global `Conventions` CF attribute."""
+
+    Conventions: str = f"CF-{_CONV_VERSION}"
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert class to dictionary."""
+        return asdict(self)
 
 
 @dataclass
@@ -61,9 +75,7 @@ class CFHealpixGridAttrs:
             # `refinement_level` is mandatory for `nested` and `ring` but must be omitted for *uniq
             # https://cfconventions.org/cf-conventions/cf-conventions.html#healpix
             if self.refinement_level is None:
-                raise ValueError(
-                    f"Indexing scheme {self.indexing_scheme!r} requires a `refinement_level` to be set."
-                )
+                raise ValueError(f"Indexing scheme {self.indexing_scheme!r} requires a `refinement_level` to be set.")
 
             try:
                 operator.index(self.refinement_level)
@@ -71,9 +83,7 @@ class CFHealpixGridAttrs:
                 TypeError,
                 ValueError,
             ):
-                raise ValueError(
-                    f"Invalid `refinement_level`: '{self.refinement_level}'; Must be integer."
-                )
+                raise ValueError(f"Invalid `refinement_level`: '{self.refinement_level}'; Must be integer.")
 
             if self.refinement_level < 0:
                 raise ValueError(f"Cannot set negative `refinement_level`: '{self.refinement_level}'.")

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -21,7 +21,7 @@ import numpy.typing as npt
 import s3fs
 import xarray as xr
 
-from .cf import HealpixNested, conventions_attrs, healpix_grid_mapping_attrs
+from .cf import HealpixNested, conventions_attrs
 from .remap import (
     _make_crs_variable,
     regrid_to_healpix,
@@ -371,7 +371,6 @@ def coarsen_healpix(
         ),
     )
 
-    cf_attrs = healpix_grid_mapping_attrs(scheme='nested', level=target_level)
     # Tag every spatially-mapped data variable.
     for name in result.data_vars:
         if "cell" in result[name].dims:
@@ -381,7 +380,6 @@ def coarsen_healpix(
     result.attrs[HEALPIX_LEVEL] = target_level
     result.attrs[HEALPIX_ORDER] = HealpixNested
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
-    result.attrs.update(cf_attrs)
     result.attrs.update(conventions_attrs())
     return result
 

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -22,7 +22,7 @@ import s3fs
 import xarray as xr
 
 from .cf import (
-    _healpix_cf_attrs,
+    healpix_grid_mapping_attrs,
 )
 from .remap import (
     _make_crs_variable,
@@ -366,7 +366,7 @@ def coarsen_healpix(
         ),
     )
 
-    cf_attrs = _healpix_cf_attrs(scheme='nested', level=target_level)
+    cf_attrs = healpix_grid_mapping_attrs(scheme='nested', level=target_level)
     # Tag every spatially-mapped data variable.
     for name in result.data_vars:
         if "cell" in result[name].dims:

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -266,8 +266,8 @@ def coarsen_healpix(
     Parameters
     ----------
     ds:
-        HEALPix dataset containing a ``cell`` dimension and the
-        attributes ``healpix_nside`` and ``healpix_order``.
+        HEALPix dataset containing the ``healpix_index`` dimension and the
+        `crs` with attributes CF attributes ``indexing_scheme`` and ``refinement_level``.
     target_level:
         Target HEALPix level (must be lower than the current level).
     coarsen_mode:

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -500,7 +500,7 @@ def save_pyramid(
     encoding:
         Per-level encoding dictionaries.
     write_coords:
-        Whether to materialise the ``cell``/``latitude``/``longitude``
+        Whether to materialise the ``healpix_index``/``latitude``/``longitude``
         coordinate arrays in the store.  HEALPix coordinates are a pure
         function of the cell index, and above roughly level 10 the
         arrays dwarf regional payloads (hundreds of GB at level 16 —

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -35,7 +35,14 @@ from .remap_backend import (
     _get_unstructured_dim,
     _is_unstructured,
 )
-from .types import CoarsenMode, FloatArray, ZarrOptions
+from .types import (
+    HEALPIX_LEVEL,
+    HEALPIX_NSIDE,
+    HEALPIX_ORDER,
+    CoarsenMode,
+    FloatArray,
+    ZarrOptions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -298,12 +305,12 @@ def coarsen_healpix(
         When the ordering is not nested, or *target_level* is not
         lower than the current level.
     """
-    current_nside = int(ds.attrs["healpix_nside"])
+    current_nside = int(ds.attrs[HEALPIX_NSIDE])
     target_nside = 2**target_level
     if target_nside >= current_nside:
         raise ValueError("target_level must be lower than the current HEALPix level.")
 
-    is_nested = str(ds.attrs.get("healpix_order", HealpixNested)) in {HealpixNested, "nest"}
+    is_nested = str(ds.attrs.get(HEALPIX_ORDER, HealpixNested)) in {HealpixNested, "nest"}
     if not is_nested:
         raise ValueError(
             "coarsen_healpix only supports nested HEALPix ordering. "
@@ -311,7 +318,7 @@ def coarsen_healpix(
             "regenerate ring levels directly."
         )
 
-    current_level = int(ds.attrs.get("healpix_level", int(np.log2(current_nside))))
+    current_level = int(ds.attrs.get(HEALPIX_LEVEL, int(np.log2(current_nside))))
     delta_level = current_level - target_level
     if delta_level <= 0:
         raise ValueError("target_level must be lower than the current HEALPix level.")
@@ -373,9 +380,9 @@ def coarsen_healpix(
         if "cell" in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
 
-    result.attrs["healpix_nside"] = target_nside
-    result.attrs["healpix_level"] = target_level
-    result.attrs["healpix_order"] = HealpixNested
+    result.attrs[HEALPIX_NSIDE] = target_nside
+    result.attrs[HEALPIX_LEVEL] = target_level
+    result.attrs[HEALPIX_ORDER] = HealpixNested
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
     result.attrs.update(cf_attrs)
     return result

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -21,6 +21,9 @@ import numpy.typing as npt
 import s3fs
 import xarray as xr
 
+from .cf import (
+    _healpix_cf_attrs,
+)
 from .remap import (
     _make_crs_variable,
     regrid_to_healpix,
@@ -363,15 +366,18 @@ def coarsen_healpix(
         ),
     )
 
+    cf_attrs = _healpix_cf_attrs(scheme='nested', level=target_level)
     # Tag every spatially-mapped data variable.
     for name in result.data_vars:
         if "cell" in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
+            result[name].attrs.update(cf_attrs)
 
     result.attrs["healpix_nside"] = target_nside
     result.attrs["healpix_level"] = target_level
     result.attrs["healpix_order"] = "nested"
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
+    result.attrs.update(cf_attrs)
     return result
 
 

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -361,16 +361,16 @@ def coarsen_healpix(
 
     result = xr.Dataset(coarsened_vars, attrs=ds.attrs.copy())
     lat_deg, lon_deg = _healpix_coords(target_level, nest=True)
-    result = result.assign_coords(
-        cell=np.arange(npix_target, dtype=np.int64),
-        latitude=(HEALPIX_INDEX, lat_deg),
-        longitude=(HEALPIX_INDEX, lon_deg),
-        crs=_make_crs_variable(
+    result = result.assign_coords({
+        HEALPIX_INDEX: np.arange(npix_target, dtype=np.int64),
+        "latitude": (HEALPIX_INDEX, lat_deg),
+        "longitude": (HEALPIX_INDEX, lon_deg),
+        "crs": _make_crs_variable(
             level=target_level,
             nside=target_nside,
             order=HealpixNested,
         ),
-    )
+    })
 
     # Tag every spatially-mapped data variable.
     for name in result.data_vars:

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -33,6 +33,7 @@ from .remap_backend import (
     _is_unstructured,
 )
 from .types import (
+    HEALPIX_INDEX,
     HEALPIX_LEVEL,
     HEALPIX_NSIDE,
     HEALPIX_ORDER,
@@ -331,11 +332,11 @@ def coarsen_healpix(
     coarsen_func = _coarsen_array_mode if resolved_mode == "mode" else _coarsen_array
 
     factor = 4**delta_level
-    npix_target = ds.sizes["cell"] // factor
+    npix_target = ds.sizes[HEALPIX_INDEX] // factor
 
     coarsened_vars: dict[str, xr.DataArray] = {}
     for name, data in ds.data_vars.items():
-        if "cell" not in data.dims:
+        if HEALPIX_INDEX not in data.dims:
             coarsened_vars[str(name)] = data
             continue
 
@@ -344,16 +345,16 @@ def coarsen_healpix(
             xr.apply_ufunc(
                 coarsen_func,
                 data,
-                input_core_dims=[["cell"]],
-                output_core_dims=[["cell"]],
-                exclude_dims={"cell"},
+                input_core_dims=[[HEALPIX_INDEX]],
+                output_core_dims=[[HEALPIX_INDEX]],
+                exclude_dims={HEALPIX_INDEX},
                 dask="parallelized",
                 kwargs={
                     "factor": factor,
                     "min_valid_fraction": min_valid_fraction,
                 },
                 output_dtypes=[np.float64],
-                dask_gufunc_kwargs={"output_sizes": {"cell": npix_target}},
+                dask_gufunc_kwargs={"output_sizes": {HEALPIX_INDEX: npix_target}},
                 keep_attrs=True,
             ),
         )
@@ -362,8 +363,8 @@ def coarsen_healpix(
     lat_deg, lon_deg = _healpix_coords(target_level, nest=True)
     result = result.assign_coords(
         cell=np.arange(npix_target, dtype=np.int64),
-        latitude=("cell", lat_deg),
-        longitude=("cell", lon_deg),
+        latitude=(HEALPIX_INDEX, lat_deg),
+        longitude=(HEALPIX_INDEX, lon_deg),
         crs=_make_crs_variable(
             level=target_level,
             nside=target_nside,
@@ -373,7 +374,7 @@ def coarsen_healpix(
 
     # Tag every spatially-mapped data variable.
     for name in result.data_vars:
-        if "cell" in result[name].dims:
+        if HEALPIX_INDEX in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
 
     result.attrs[HEALPIX_NSIDE] = target_nside
@@ -524,7 +525,7 @@ def save_pyramid(
         )
         if not include_coords:
             dataset = dataset.drop_vars(
-                ["latitude", "longitude", "cell"], errors="ignore"
+                ["latitude", "longitude", HEALPIX_INDEX], errors="ignore"
             )
             dataset.attrs["grid_doctor_implicit_coords"] = 1
         level_path = f"{path}/level_{level}.zarr"

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -21,10 +21,7 @@ import numpy.typing as npt
 import s3fs
 import xarray as xr
 
-from .cf import (
-    HealpixNested,
-    healpix_grid_mapping_attrs,
-)
+from .cf import HealpixNested, conventions_attrs, healpix_grid_mapping_attrs
 from .remap import (
     _make_crs_variable,
     regrid_to_healpix,
@@ -385,6 +382,7 @@ def coarsen_healpix(
     result.attrs[HEALPIX_ORDER] = HealpixNested
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
     result.attrs.update(cf_attrs)
+    result.attrs.update(conventions_attrs())
     return result
 
 

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -371,7 +371,6 @@ def coarsen_healpix(
     for name in result.data_vars:
         if "cell" in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
-            result[name].attrs.update(cf_attrs)
 
     result.attrs["healpix_nside"] = target_nside
     result.attrs["healpix_level"] = target_level

--- a/src/grid_doctor/helpers.py
+++ b/src/grid_doctor/helpers.py
@@ -22,6 +22,7 @@ import s3fs
 import xarray as xr
 
 from .cf import (
+    HealpixNested,
     healpix_grid_mapping_attrs,
 )
 from .remap import (
@@ -302,7 +303,7 @@ def coarsen_healpix(
     if target_nside >= current_nside:
         raise ValueError("target_level must be lower than the current HEALPix level.")
 
-    is_nested = str(ds.attrs.get("healpix_order", "nested")) in {"nested", "nest"}
+    is_nested = str(ds.attrs.get("healpix_order", HealpixNested)) in {HealpixNested, "nest"}
     if not is_nested:
         raise ValueError(
             "coarsen_healpix only supports nested HEALPix ordering. "
@@ -362,7 +363,7 @@ def coarsen_healpix(
         crs=_make_crs_variable(
             level=target_level,
             nside=target_nside,
-            order="nested",
+            order=HealpixNested,
         ),
     )
 
@@ -374,7 +375,7 @@ def coarsen_healpix(
 
     result.attrs["healpix_nside"] = target_nside
     result.attrs["healpix_level"] = target_level
-    result.attrs["healpix_order"] = "nested"
+    result.attrs["healpix_order"] = HealpixNested
     result.attrs["grid_doctor_coarsened_from_level"] = current_level
     result.attrs.update(cf_attrs)
     return result

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -25,6 +25,7 @@ import numpy as np
 import xarray as xr
 
 from .cf import (
+    HealpixIndexScheme,
     _healpix_cf_attrs,
 )
 from .remap_apply import (
@@ -46,7 +47,6 @@ from .remap_backend import (
 from .types import (
     ApplyBackend,
     FloatArray,
-    HealpixIndexScheme,
     MissingPolicy,
     RemapMethod,
     SourceKind,

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -576,7 +576,7 @@ def _make_crs_variable(
             "healpix_nside": nside,
             "healpix_level": level,
             "healpix_order": order,
-        } | _healpix_cf_attrs(order, level)
+        } | dict(_healpix_cf_attrs(order, level))
     )
 
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -26,7 +26,7 @@ import xarray as xr
 
 from .cf import (
     HealpixIndexScheme,
-    _healpix_cf_attrs,
+    healpix_grid_mapping_attrs,
 )
 from .remap_apply import (
     apply_weights_nd,
@@ -545,7 +545,7 @@ def _attach_healpix_coords(
     if method is not None:
         ds_hp.attrs["grid_doctor_method"] = method
 
-    ds_hp.attrs.update(_healpix_cf_attrs(order, level))
+    ds_hp.attrs.update(healpix_grid_mapping_attrs(order, level))
 
     return ds_hp
 
@@ -577,7 +577,7 @@ def _make_crs_variable(
             "healpix_nside": nside,
             "healpix_level": level,
             "healpix_order": order,
-        } | dict(_healpix_cf_attrs(order, level))
+        } | dict(healpix_grid_mapping_attrs(order, level))
     )
 
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -26,6 +26,8 @@ import xarray as xr
 
 from .cf import (
     HealpixIndexScheme,
+    HealpixNested,
+    HealpixRing,
     healpix_grid_mapping_attrs,
 )
 from .remap_apply import (
@@ -146,7 +148,7 @@ def _read_weight_file(
             values=wds[val_name].values,
         )
         level = int(wds.attrs.get("grid_doctor_level", -1))
-        order = str(wds.attrs.get("grid_doctor_order", "nested"))
+        order = str(wds.attrs.get("grid_doctor_order", HealpixNested))
         method_raw = wds.attrs.get("grid_doctor_method")
         method = str(method_raw) if method_raw is not None else None
         stored_source_dims = _parse_source_dims_attr(
@@ -488,7 +490,7 @@ def apply_weight_file(
         result = _attach_healpix_coords(
             result,
             level=level,
-            nest=(order == "nested"),
+            nest=(order == HealpixNested),
             method=method,
         )
     return result
@@ -520,7 +522,7 @@ def _attach_healpix_coords(
     import grid_doctor as _gd
 
     nside = 2**level
-    order: HealpixIndexScheme = "nested" if nest else "ring"
+    order: HealpixIndexScheme = HealpixNested if nest else HealpixRing
 
     lat_deg, lon_deg = _healpix_centres(level, nest=nest)
     ds_hp = ds_hp.assign_coords(

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -553,7 +553,7 @@ def _make_crs_variable(
     *,
     level: int,
     nside: int,
-    order: str,
+    order: HealpixIndexScheme,
 ) -> xr.DataArray:
     """Create a scalar CRS coordinate variable for HEALPix.
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -28,6 +28,7 @@ from .cf import (
     HealpixIndexScheme,
     HealpixNested,
     HealpixRing,
+    conventions_attrs,
     healpix_grid_mapping_attrs,
 )
 from .remap_apply import (
@@ -551,6 +552,7 @@ def _attach_healpix_coords(
         ds_hp.attrs["grid_doctor_method"] = method
 
     ds_hp.attrs.update(healpix_grid_mapping_attrs(order, level))
+    ds_hp.attrs.update(conventions_attrs())
 
     return ds_hp
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -47,6 +47,9 @@ from .remap_backend import (
     compute_healpix_weights_backend,
 )
 from .types import (
+    HEALPIX_LEVEL,
+    HEALPIX_NSIDE,
+    HEALPIX_ORDER,
     ApplyBackend,
     FloatArray,
     MissingPolicy,
@@ -538,9 +541,9 @@ def _attach_healpix_coords(
             ds_hp[name].attrs["grid_mapping"] = "crs"
 
     # Global HEALPix metadata.
-    ds_hp.attrs["healpix_level"] = level
-    ds_hp.attrs["healpix_nside"] = nside
-    ds_hp.attrs["healpix_order"] = order
+    ds_hp.attrs[HEALPIX_LEVEL] = level
+    ds_hp.attrs[HEALPIX_NSIDE] = nside
+    ds_hp.attrs[HEALPIX_ORDER] = order
 
     # Provenance.
     ds_hp.attrs["grid_doctor_version"] = _gd.__version__
@@ -576,9 +579,9 @@ def _make_crs_variable(
         np.float64(0.0),
         attrs={
             "grid_mapping_name": "healpix",
-            "healpix_nside": nside,
-            "healpix_level": level,
-            "healpix_order": order,
+            HEALPIX_NSIDE: nside,
+            HEALPIX_LEVEL: level,
+            HEALPIX_ORDER: order,
         } | dict(healpix_grid_mapping_attrs(order, level))
     )
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -551,7 +551,6 @@ def _attach_healpix_coords(
     if method is not None:
         ds_hp.attrs["grid_doctor_method"] = method
 
-    ds_hp.attrs.update(healpix_grid_mapping_attrs(order, level))
     ds_hp.attrs.update(conventions_attrs())
 
     return ds_hp

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -46,6 +46,7 @@ from .remap_backend import (
 from .types import (
     ApplyBackend,
     FloatArray,
+    HealpixIndexScheme,
     MissingPolicy,
     RemapMethod,
     SourceKind,
@@ -519,7 +520,7 @@ def _attach_healpix_coords(
     import grid_doctor as _gd
 
     nside = 2**level
-    order = "nested" if nest else "ring"
+    order: HealpixIndexScheme = "nested" if nest else "ring"
 
     lat_deg, lon_deg = _healpix_centres(level, nest=nest)
     ds_hp = ds_hp.assign_coords(

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -48,6 +48,7 @@ from .remap_backend import (
     compute_healpix_weights_backend,
 )
 from .types import (
+    HEALPIX_INDEX,
     HEALPIX_LEVEL,
     HEALPIX_NSIDE,
     HEALPIX_ORDER,
@@ -475,7 +476,7 @@ def apply_weight_file(
                 apply_weights_nd,
                 data,
                 input_core_dims=[list(resolved_sd)],
-                output_core_dims=[["cell"]],
+                output_core_dims=[[HEALPIX_INDEX]],
                 exclude_dims=set(resolved_sd),
                 dask="parallelized",
                 kwargs={
@@ -485,7 +486,7 @@ def apply_weight_file(
                     "backend": backend,
                 },
                 output_dtypes=[np.float64],
-                dask_gufunc_kwargs={"output_sizes": {"cell": n_target}},
+                dask_gufunc_kwargs={"output_sizes": {HEALPIX_INDEX: n_target}},
             ),
         )
 
@@ -531,14 +532,14 @@ def _attach_healpix_coords(
     lat_deg, lon_deg = _healpix_centres(level, nest=nest)
     ds_hp = ds_hp.assign_coords(
         cell=np.arange(lat_deg.size, dtype=np.int64),
-        latitude=("cell", lat_deg),
-        longitude=("cell", lon_deg),
+        latitude=(HEALPIX_INDEX, lat_deg),
+        longitude=(HEALPIX_INDEX, lon_deg),
         crs=_make_crs_variable(level=level, nside=nside, order=order),
     )
 
     # Tag every spatially-mapped data variable.
     for name in ds_hp.data_vars:
-        if "cell" in ds_hp[name].dims:
+        if HEALPIX_INDEX in ds_hp[name].dims:
             ds_hp[name].attrs["grid_mapping"] = "crs"
 
     # Global HEALPix metadata.

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -24,6 +24,9 @@ from typing import Any, cast
 import numpy as np
 import xarray as xr
 
+from .cf import (
+    _healpix_cf_attrs,
+)
 from .remap_apply import (
     apply_weights_nd,
     extract_sparse_weights,
@@ -540,6 +543,8 @@ def _attach_healpix_coords(
     ds_hp.attrs["grid_doctor_version"] = _gd.__version__
     if method is not None:
         ds_hp.attrs["grid_doctor_method"] = method
+
+    ds_hp.attrs.update(_healpix_cf_attrs(order, level))
 
     return ds_hp
 

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -519,7 +519,7 @@ def _attach_healpix_coords(
 
     - ``cell``, ``latitude``, ``longitude`` coordinates.
     - A scalar ``crs`` coordinate variable whose attributes describe the
-      HEALPix grid (``grid_mapping_name``, ``healpix_nside``, …).
+      HEALPix grid (``grid_mapping_name``, ``indexing_scheme``, …).
     - ``grid_mapping = "crs"`` on every data variable so that CF-aware
       tools can discover the projection automatically.
     - Global provenance attributes (``healpix_*``, ``grid_doctor_*``).

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -530,12 +530,12 @@ def _attach_healpix_coords(
     order: HealpixIndexScheme = HealpixNested if nest else HealpixRing
 
     lat_deg, lon_deg = _healpix_centres(level, nest=nest)
-    ds_hp = ds_hp.assign_coords(
-        cell=np.arange(lat_deg.size, dtype=np.int64),
-        latitude=(HEALPIX_INDEX, lat_deg),
-        longitude=(HEALPIX_INDEX, lon_deg),
-        crs=_make_crs_variable(level=level, nside=nside, order=order),
-    )
+    ds_hp = ds_hp.assign_coords({
+        HEALPIX_INDEX: np.arange(lat_deg.size, dtype=np.int64),
+        "latitude": (HEALPIX_INDEX, lat_deg),
+        "longitude": (HEALPIX_INDEX, lon_deg),
+        "crs": _make_crs_variable(level=level, nside=nside, order=order),
+    })
 
     # Tag every spatially-mapped data variable.
     for name in ds_hp.data_vars:

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -439,7 +439,7 @@ def apply_weight_file(
     Returns
     -------
     xarray.Dataset
-        Dataset on the HEALPix target grid with a ``cell`` dimension.
+        Dataset on the HEALPix target grid with a ``healpix_index`` dimension.
 
     Examples
     --------
@@ -517,7 +517,7 @@ def _attach_healpix_coords(
 
     Adds:
 
-    - ``cell``, ``latitude``, ``longitude`` coordinates.
+    - ``healpix_index``, ``latitude``, ``longitude`` coordinates.
     - A scalar ``crs`` coordinate variable whose attributes describe the
       HEALPix grid (``grid_mapping_name``, ``indexing_scheme``, …).
     - ``grid_mapping = "crs"`` on every data variable so that CF-aware

--- a/src/grid_doctor/remap.py
+++ b/src/grid_doctor/remap.py
@@ -576,7 +576,7 @@ def _make_crs_variable(
             "healpix_nside": nside,
             "healpix_level": level,
             "healpix_order": order,
-        },
+        } | _healpix_cf_attrs(order, level)
     )
 
 

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -1929,7 +1929,7 @@ def _run_offline_esmf(
         workdir = config.workdir
         workdir.mkdir(parents=True, exist_ok=True)
 
-    order_tag = "nest" if nest else HealpixRing
+    order_tag = HealpixNested if nest else HealpixRing
     src_file = write_ugrid_mesh_file(
         source_desc.source_mesh,
         workdir / "source_mesh.nc",

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -1641,7 +1641,7 @@ def describe_source(
             useful for spectral inputs that need an external transform.
         grid: Optional grid dataset that supplies geometry when the
             data file itself only contains values on dimensions such
-            as ``cell``.
+            as ``healpix_index``.
         source_kind: Explicit source representation.  Use ``"auto"``
             to infer it from the available coordinates.
         source_units: Angular unit convention of the source

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -39,6 +39,7 @@ from .cf import (
     HealpixRing,
 )
 from .types import (
+    HEALPIX_INDEX,
     FloatArray,
     Int64Array,
     IntArray,
@@ -54,7 +55,7 @@ logger = logging.getLogger(__name__)
 # Well-known coordinate and dimension names
 # ---------------------------------------------------------------------------
 
-_UNSTRUCTURED_DIMS: frozenset[str] = frozenset({"cell", "ncells", "ncell", "nCells"})
+_UNSTRUCTURED_DIMS: frozenset[str] = frozenset({HEALPIX_INDEX, "cell", "ncells", "ncell", "nCells"})
 """Dimension names that signal an unstructured source grid."""
 
 _LAT_NAMES: tuple[str, ...] = (

--- a/src/grid_doctor/remap_backend.py
+++ b/src/grid_doctor/remap_backend.py
@@ -34,6 +34,10 @@ from typing import Any, Literal, cast, overload
 import numpy as np
 import xarray as xr
 
+from .cf import (
+    HealpixNested,
+    HealpixRing,
+)
 from .types import (
     FloatArray,
     Int64Array,
@@ -1858,7 +1862,7 @@ def compute_healpix_weights_backend(
     meta: dict[str, str | int | float | bool] = {
         "grid_doctor_method": method,
         "grid_doctor_level": level,
-        "grid_doctor_order": "nested" if nest else "ring",
+        "grid_doctor_order": HealpixNested if nest else HealpixRing,
         "grid_doctor_backend": ("offline-esmf" if use_offline else "esmpy"),
         "grid_doctor_ignore_unmapped": int(bool(eff_ignore)),
         **source_desc.metadata,
@@ -1924,7 +1928,7 @@ def _run_offline_esmf(
         workdir = config.workdir
         workdir.mkdir(parents=True, exist_ok=True)
 
-    order_tag = "nest" if nest else "ring"
+    order_tag = "nest" if nest else HealpixRing
     src_file = write_ugrid_mesh_file(
         source_desc.source_mesh,
         workdir / "source_mesh.nc",

--- a/src/grid_doctor/select.py
+++ b/src/grid_doctor/select.py
@@ -19,7 +19,7 @@ merged into contiguous runs, and read as a handful of contiguous slices
 power of four.
 
 The returned subset is the compact ("sparse") representation also
-produced by ``bin_to_healpix(..., dense=False)``: the ``cell``
+produced by ``bin_to_healpix(..., dense=False)``: the ``healpix_index``
 coordinate holds the actual global HEALPix indices, cell-centre
 ``latitude``/``longitude`` are computed on the fly for exactly the
 selected cells, and ``grid_doctor_sparse = 1`` is set.
@@ -114,7 +114,7 @@ def select_cells(
     """Extract the given HEALPix cells from a dataset.
 
     Works on dense datasets (positional index equals cell ID, with or
-    without materialised coordinates) and on compact subsets (``cell``
+    without materialised coordinates) and on compact subsets (``healpix_index``
     coordinate holds actual IDs).  Contiguous ID runs are read as
     contiguous slices, so a spatially compact selection touches only
     the chunks it needs.
@@ -137,7 +137,7 @@ def select_cells(
     Returns
     -------
     xarray.Dataset
-        Compact subset: ``cell`` coordinate holds the requested IDs,
+        Compact subset: ``healpix_index`` coordinate holds the requested IDs,
         cell-centre ``latitude``/``longitude`` are attached, and
         ``grid_doctor_sparse = 1`` is set.
     """
@@ -311,9 +311,9 @@ def attach_cell_coords(
     Parameters
     ----------
     ds:
-        Subset whose ``cell`` dimension corresponds to *cells*.
+        Subset whose ``healpix_index`` dimension corresponds to *cells*.
     cells:
-        Global HEALPix cell IDs, one per position along ``cell``.
+        Global HEALPix cell IDs, one per position along ``healpix_index``.
     level:
         HEALPix level of the IDs.
     attrs:
@@ -323,7 +323,7 @@ def attach_cell_coords(
     Returns
     -------
     xarray.Dataset
-        Subset with ``cell``, ``latitude``, ``longitude``, and ``crs``
+        Subset with ``healpix_index``, ``latitude``, ``longitude``, and ``crs``
         coordinates, ``grid_mapping`` tags, and ``grid_doctor_sparse``
         set.
     """

--- a/src/grid_doctor/select.py
+++ b/src/grid_doctor/select.py
@@ -42,7 +42,13 @@ import xarray as xr
 from .cf import HealpixNested
 from .remap import _make_crs_variable
 from .remap_backend import _canonical_lon, _require_healpix_geo_module
-from .types import HEALPIX_LEVEL, HEALPIX_NSIDE, HEALPIX_ORDER, Int64Array
+from .types import (
+    HEALPIX_INDEX,
+    HEALPIX_LEVEL,
+    HEALPIX_NSIDE,
+    HEALPIX_ORDER,
+    Int64Array,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,10 +152,10 @@ def select_cells(
             f"Cell IDs must be within [0, {npix}) for level {resolved_level}."
         )
 
-    if "cell" in ds.coords:
+    if HEALPIX_INDEX in ds.coords:
         # Compact dataset (or legacy dense store with coordinates):
         # positions are found through the coordinate values.
-        coord = np.asarray(ds["cell"].values, dtype=np.int64)
+        coord = np.asarray(ds[HEALPIX_INDEX].values, dtype=np.int64)
         pos = np.searchsorted(coord, wanted)
         pos = np.clip(pos, 0, coord.size - 1)
         present = coord[pos] == wanted
@@ -159,16 +165,16 @@ def select_cells(
                 f"{missing.size} requested cells are not present in the "
                 f"dataset (first missing: {int(missing[0])})."
             )
-        pieces = [ds.isel(cell=slice(a, b)) for a, b in _contiguous_runs(pos)]
+        pieces = [ds.isel({HEALPIX_INDEX: slice(a, b)}) for a, b in _contiguous_runs(pos)]
     else:
         # Dense store without materialised coordinates: positional
         # index *is* the cell ID.
-        pieces = [ds.isel(cell=slice(a, b)) for a, b in _contiguous_runs(wanted)]
+        pieces = [ds.isel({HEALPIX_INDEX: slice(a, b)}) for a, b in _contiguous_runs(wanted)]
 
     subset = (
         pieces[0]
         if len(pieces) == 1
-        else xr.concat(pieces, dim="cell", data_vars="minimal", coords="minimal")
+        else xr.concat(pieces, dim=HEALPIX_INDEX, data_vars="minimal", coords="minimal")
     )
     if load:
         subset = subset.load()
@@ -322,9 +328,9 @@ def attach_cell_coords(
         set.
     """
     cells = np.asarray(cells, dtype=np.int64)
-    if ds.sizes.get("cell") != cells.size:
+    if ds.sizes.get(HEALPIX_INDEX) != cells.size:
         raise ValueError(
-            f"Dataset has {ds.sizes.get('cell')} cells but {cells.size} "
+            f"Dataset has {ds.sizes.get(HEALPIX_INDEX)} cells but {cells.size} "
             "IDs were provided."
         )
     module, kwargs = _require_healpix_geo_module(nest=True)
@@ -332,15 +338,15 @@ def attach_cell_coords(
 
     result = ds.assign_coords(
         cell=cells,
-        latitude=("cell", np.asarray(lat_deg, dtype=np.float64)),
+        latitude=(HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
         longitude=(
-            "cell",
+            HEALPIX_INDEX,
             _canonical_lon(np.asarray(lon_deg, dtype=np.float64)),
         ),
         crs=_make_crs_variable(level=level, nside=2**level, order=HealpixNested),
     )
     for name in result.data_vars:
-        if "cell" in result[name].dims:
+        if HEALPIX_INDEX in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
     if attrs:
         merged = dict(attrs)

--- a/src/grid_doctor/select.py
+++ b/src/grid_doctor/select.py
@@ -39,6 +39,7 @@ from typing import Any
 import numpy as np
 import xarray as xr
 
+from .cf import HealpixNested
 from .remap import _make_crs_variable
 from .remap_backend import _canonical_lon, _require_healpix_geo_module
 from .types import Int64Array
@@ -87,8 +88,8 @@ def _dataset_level(ds: xr.Dataset, level: int | None) -> int:
 
 def _require_nested(ds: xr.Dataset) -> None:
     """Range-based selection relies on nested ordering."""
-    order = str(ds.attrs.get("healpix_order", "nested"))
-    if order not in {"nested", "nest"}:
+    order = str(ds.attrs.get("healpix_order", HealpixNested))
+    if order not in {HealpixNested, "nest"}:
         raise ValueError(f"Region selection requires nested ordering, got {order!r}.")
 
 
@@ -336,7 +337,7 @@ def attach_cell_coords(
             "cell",
             _canonical_lon(np.asarray(lon_deg, dtype=np.float64)),
         ),
-        crs=_make_crs_variable(level=level, nside=2**level, order="nested"),
+        crs=_make_crs_variable(level=level, nside=2**level, order=HealpixNested),
     )
     for name in result.data_vars:
         if "cell" in result[name].dims:
@@ -347,7 +348,7 @@ def attach_cell_coords(
         result.attrs = merged
     result.attrs["healpix_level"] = level
     result.attrs["healpix_nside"] = 2**level
-    result.attrs["healpix_order"] = "nested"
+    result.attrs["healpix_order"] = HealpixNested
     result.attrs["grid_doctor_sparse"] = 1
     return result
 

--- a/src/grid_doctor/select.py
+++ b/src/grid_doctor/select.py
@@ -125,7 +125,7 @@ def select_cells(
         HEALPix dataset, typically opened with
         ``xr.open_zarr(store, chunks=None)``.
     cells:
-        Global HEALPix cell IDs to extract (any order; duplicates are
+        Global HEALPix index IDs to extract (any order; duplicates are
         dropped).
     level:
         HEALPix level override when the ``healpix_level`` attribute is
@@ -337,13 +337,15 @@ def attach_cell_coords(
     lon_deg, lat_deg = module.healpix_to_lonlat(cells, level, **kwargs)
 
     result = ds.assign_coords(
-        cell=cells,
-        latitude=(HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
-        longitude=(
-            HEALPIX_INDEX,
-            _canonical_lon(np.asarray(lon_deg, dtype=np.float64)),
-        ),
-        crs=_make_crs_variable(level=level, nside=2**level, order=HealpixNested),
+        {
+            HEALPIX_INDEX: cells,
+            "latitude": (HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
+            "longitude": (
+                HEALPIX_INDEX,
+                _canonical_lon(np.asarray(lon_deg, dtype=np.float64)),
+            ),
+            "crs": _make_crs_variable(level=level, nside=2**level, order=HealpixNested),
+        }
     )
     for name in result.data_vars:
         if HEALPIX_INDEX in result[name].dims:

--- a/src/grid_doctor/select.py
+++ b/src/grid_doctor/select.py
@@ -42,7 +42,7 @@ import xarray as xr
 from .cf import HealpixNested
 from .remap import _make_crs_variable
 from .remap_backend import _canonical_lon, _require_healpix_geo_module
-from .types import Int64Array
+from .types import HEALPIX_LEVEL, HEALPIX_NSIDE, HEALPIX_ORDER, Int64Array
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def _dataset_level(ds: xr.Dataset, level: int | None) -> int:
     if level is not None:
         return level
     try:
-        return int(ds.attrs["healpix_level"])
+        return int(ds.attrs[HEALPIX_LEVEL])
     except KeyError:
         raise ValueError(
             "Dataset has no `healpix_level` attribute; pass `level=` explicitly."
@@ -88,7 +88,7 @@ def _dataset_level(ds: xr.Dataset, level: int | None) -> int:
 
 def _require_nested(ds: xr.Dataset) -> None:
     """Range-based selection relies on nested ordering."""
-    order = str(ds.attrs.get("healpix_order", HealpixNested))
+    order = str(ds.attrs.get(HEALPIX_ORDER, HealpixNested))
     if order not in {HealpixNested, "nest"}:
         raise ValueError(f"Region selection requires nested ordering, got {order!r}.")
 
@@ -346,9 +346,9 @@ def attach_cell_coords(
         merged = dict(attrs)
         merged.update(result.attrs)
         result.attrs = merged
-    result.attrs["healpix_level"] = level
-    result.attrs["healpix_nside"] = 2**level
-    result.attrs["healpix_order"] = HealpixNested
+    result.attrs[HEALPIX_LEVEL] = level
+    result.attrs[HEALPIX_NSIDE] = 2**level
+    result.attrs[HEALPIX_ORDER] = HealpixNested
     result.attrs["grid_doctor_sparse"] = 1
     return result
 

--- a/src/grid_doctor/swath/__init__.py
+++ b/src/grid_doctor/swath/__init__.py
@@ -73,6 +73,7 @@ from ..remap_backend import (
     _require_healpix_geo_module,
 )
 from ..types import (
+    HEALPIX_INDEX,
     HEALPIX_LEVEL,
     HEALPIX_NSIDE,
     HEALPIX_ORDER,
@@ -276,11 +277,11 @@ def bin_to_healpix(
             key: value for key, value in da.attrs.items() if key not in FILL_ATTR_NAMES
         }
         attrs["grid_doctor_method"] = AGG_TO_METHOD[method]
-        binned[var_name] = xr.DataArray(result, dims=(*batch_dims, "cell"), attrs=attrs)
+        binned[var_name] = xr.DataArray(result, dims=(*batch_dims, HEALPIX_INDEX), attrs=attrs)
         if with_counts and method != "count":
             counts[f"{var_name}_count"] = xr.DataArray(
                 valid_count.astype(np.int32),
-                dims=(*batch_dims, "cell"),
+                dims=(*batch_dims, HEALPIX_INDEX),
                 attrs={"long_name": f"number of valid samples binned into {var_name}"},
             )
 
@@ -325,9 +326,9 @@ def sparse_to_dense(ds: xr.Dataset) -> xr.Dataset:
         raise ValueError("Dataset is not a sparse binned dataset.")
     level = int(ds.attrs[HEALPIX_LEVEL])
     nest = str(ds.attrs.get(HEALPIX_ORDER, HealpixNested)) in {HealpixNested, "nest"}
-    cell_ids = np.asarray(ds["cell"].values, dtype=np.int64)
+    cell_ids = np.asarray(ds[HEALPIX_INDEX].values, dtype=np.int64)
     stripped = ds.drop_vars(
-        [name for name in ("latitude", "longitude", "crs", "cell") if name in ds]
+        [name for name in ("latitude", "longitude", "crs", HEALPIX_INDEX) if name in ds]
     )
     return _scatter_to_dense(stripped, cell_ids, level=level, nest=nest)
 
@@ -367,10 +368,10 @@ def _scatter_to_dense(
     npix = 12 * 4**level
     scattered: dict[str, xr.DataArray] = {}
     for name, da in ds.data_vars.items():
-        if "cell" not in da.dims:
+        if HEALPIX_INDEX not in da.dims:
             scattered[str(name)] = da
             continue
-        arranged = da.transpose(..., "cell")
+        arranged = da.transpose(..., HEALPIX_INDEX)
         if np.issubdtype(arranged.dtype, np.integer):
             full = np.zeros((*arranged.shape[:-1], npix), dtype=arranged.dtype)
         else:
@@ -382,7 +383,7 @@ def _scatter_to_dense(
         {
             str(coord): ds.coords[coord]
             for coord in ds.coords
-            if "cell" not in ds.coords[coord].dims and str(coord) != "cell"
+            if HEALPIX_INDEX not in ds.coords[coord].dims and str(coord) != HEALPIX_INDEX
         }
     )
     dense.attrs.pop("grid_doctor_sparse", None)
@@ -411,14 +412,14 @@ def _attach_sparse_coords(
 
     result = ds.assign_coords(
         cell=cell_ids,
-        latitude=("cell", np.asarray(lat_deg, dtype=np.float64)),
-        longitude=("cell", _canonical_lon(np.asarray(lon_deg, dtype=np.float64))),
+        latitude=(HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
+        longitude=(HEALPIX_INDEX, _canonical_lon(np.asarray(lon_deg, dtype=np.float64))),
         crs=_make_crs_variable(
             level=level, nside=2**level, order=HealpixNested if nest else HealpixRing
         ),
     )
     for name in result.data_vars:
-        if "cell" in result[name].dims:
+        if HEALPIX_INDEX in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"
 
     import grid_doctor as _gd

--- a/src/grid_doctor/swath/__init__.py
+++ b/src/grid_doctor/swath/__init__.py
@@ -400,8 +400,8 @@ def _attach_sparse_coords(
 ) -> xr.Dataset:
     """Attach coordinates and metadata to a compact binned dataset.
 
-    The ``cell`` coordinate holds the *actual* HEALPix indices of the
-    touched cells (unlike the dense representation, where ``cell`` is a
+    The ``healpix_index`` coordinate holds the *actual* HEALPix indices of the
+    touched cells (unlike the dense representation, where ``healpix_index`` is a
     positional ``arange``).  The dataset is marked with
     ``grid_doctor_sparse = 1``.
     """
@@ -410,14 +410,14 @@ def _attach_sparse_coords(
 
     from ..remap import _make_crs_variable
 
-    result = ds.assign_coords(
-        cell=cell_ids,
-        latitude=(HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
-        longitude=(HEALPIX_INDEX, _canonical_lon(np.asarray(lon_deg, dtype=np.float64))),
-        crs=_make_crs_variable(
+    result = ds.assign_coords({
+        HEALPIX_INDEX: cell_ids,
+        "latitude": (HEALPIX_INDEX, np.asarray(lat_deg, dtype=np.float64)),
+        "longitude": (HEALPIX_INDEX, _canonical_lon(np.asarray(lon_deg, dtype=np.float64))),
+        "crs": _make_crs_variable(
             level=level, nside=2**level, order=HealpixNested if nest else HealpixRing
         ),
-    )
+    })
     for name in result.data_vars:
         if HEALPIX_INDEX in result[name].dims:
             result[name].attrs["grid_mapping"] = "crs"

--- a/src/grid_doctor/swath/__init__.py
+++ b/src/grid_doctor/swath/__init__.py
@@ -72,7 +72,14 @@ from ..remap_backend import (
     _canonical_lon,
     _require_healpix_geo_module,
 )
-from ..types import BinAgg, Int64Array, SourceUnits
+from ..types import (
+    HEALPIX_LEVEL,
+    HEALPIX_NSIDE,
+    HEALPIX_ORDER,
+    BinAgg,
+    Int64Array,
+    SourceUnits,
+)
 from .utils import (
     AGG_TO_METHOD,
     FILL_ATTR_NAMES,
@@ -316,8 +323,8 @@ def sparse_to_dense(ds: xr.Dataset) -> xr.Dataset:
     """
     if int(ds.attrs.get("grid_doctor_sparse", 0)) != 1:
         raise ValueError("Dataset is not a sparse binned dataset.")
-    level = int(ds.attrs["healpix_level"])
-    nest = str(ds.attrs.get("healpix_order", HealpixNested)) in {HealpixNested, "nest"}
+    level = int(ds.attrs[HEALPIX_LEVEL])
+    nest = str(ds.attrs.get(HEALPIX_ORDER, HealpixNested)) in {HealpixNested, "nest"}
     cell_ids = np.asarray(ds["cell"].values, dtype=np.int64)
     stripped = ds.drop_vars(
         [name for name in ("latitude", "longitude", "crs", "cell") if name in ds]
@@ -416,9 +423,9 @@ def _attach_sparse_coords(
 
     import grid_doctor as _gd
 
-    result.attrs["healpix_level"] = level
-    result.attrs["healpix_nside"] = 2**level
-    result.attrs["healpix_order"] = HealpixNested if nest else HealpixRing
+    result.attrs[HEALPIX_LEVEL] = level
+    result.attrs[HEALPIX_NSIDE] = 2**level
+    result.attrs[HEALPIX_ORDER] = HealpixNested if nest else HealpixRing
     result.attrs["grid_doctor_version"] = _gd.__version__
     result.attrs["grid_doctor_sparse"] = 1
     return result

--- a/src/grid_doctor/swath/__init__.py
+++ b/src/grid_doctor/swath/__init__.py
@@ -175,7 +175,7 @@ def bin_to_healpix(
         [`coarsen_healpix`][grid_doctor.helpers.coarsen_healpix] and
         [`save_pyramid`][grid_doctor.helpers.save_pyramid].  When
         *False*, return a compact dataset containing only the touched
-        cells (the ``cell`` coordinate holds the actual HEALPix
+        cells (the ``healpix_index`` coordinate holds the actual HEALPix
         indices) — useful as a per-granule intermediate at high levels;
         convert with
         [`sparse_to_dense`][grid_doctor.swath.sparse_to_dense] before

--- a/src/grid_doctor/swath/__init__.py
+++ b/src/grid_doctor/swath/__init__.py
@@ -63,6 +63,10 @@ from collections.abc import Mapping
 import numpy as np
 import xarray as xr
 
+from ..cf import (
+    HealpixNested,
+    HealpixRing,
+)
 from ..remap import _attach_healpix_coords
 from ..remap_backend import (
     _canonical_lon,
@@ -313,7 +317,7 @@ def sparse_to_dense(ds: xr.Dataset) -> xr.Dataset:
     if int(ds.attrs.get("grid_doctor_sparse", 0)) != 1:
         raise ValueError("Dataset is not a sparse binned dataset.")
     level = int(ds.attrs["healpix_level"])
-    nest = str(ds.attrs.get("healpix_order", "nested")) in {"nested", "nest"}
+    nest = str(ds.attrs.get("healpix_order", HealpixNested)) in {HealpixNested, "nest"}
     cell_ids = np.asarray(ds["cell"].values, dtype=np.int64)
     stripped = ds.drop_vars(
         [name for name in ("latitude", "longitude", "crs", "cell") if name in ds]
@@ -403,7 +407,7 @@ def _attach_sparse_coords(
         latitude=("cell", np.asarray(lat_deg, dtype=np.float64)),
         longitude=("cell", _canonical_lon(np.asarray(lon_deg, dtype=np.float64))),
         crs=_make_crs_variable(
-            level=level, nside=2**level, order="nested" if nest else "ring"
+            level=level, nside=2**level, order=HealpixNested if nest else HealpixRing
         ),
     )
     for name in result.data_vars:
@@ -414,7 +418,7 @@ def _attach_sparse_coords(
 
     result.attrs["healpix_level"] = level
     result.attrs["healpix_nside"] = 2**level
-    result.attrs["healpix_order"] = "nested" if nest else "ring"
+    result.attrs["healpix_order"] = HealpixNested if nest else HealpixRing
     result.attrs["grid_doctor_version"] = _gd.__version__
     result.attrs["grid_doctor_sparse"] = 1
     return result

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -38,6 +38,9 @@ MissingPolicy = Literal["renormalize", "propagate"]
 ApplyBackend = Literal["auto", "scipy", "numba", "cupy"]
 """Which application backend to use."""
 
+HealpixIndexScheme = Literal["nested", "ring", "zuniq", "nuniq"]
+"""Allowed Healpix indexing schemes."""
+
 
 class ZarrOptions(TypedDict, total=False):
     """Definitions of possible to_zarr arguments."""

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -1,6 +1,6 @@
 """Special type definitions."""
 
-from typing import Any, Callable, Dict, Literal, TypedDict
+from typing import Any, Callable, Dict, Final, Literal, TypedDict
 
 import numpy as np
 import numpy.typing as npt
@@ -37,6 +37,16 @@ MissingPolicy = Literal["renormalize", "propagate"]
 
 ApplyBackend = Literal["auto", "scipy", "numba", "cupy"]
 """Which application backend to use."""
+
+# Ad-hoc key names used for healpix attrs
+HEALPIX_LEVEL: Final = "healpix_level"
+"""\"Healpix_level\" is equivalent in CF vocabulary to refinement_level."""
+
+HEALPIX_NSIDE: Final = "healpix_nside"
+"""\"healpix_nside\" is the number of pixels per size in, not required by the healpix CF convention."""
+
+HEALPIX_ORDER: Final = "healpix_order"
+"""\"Healpix_order\" is equivalent in CF vocabulary to indexing_scheme."""
 
 
 class ZarrOptions(TypedDict, total=False):

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -40,14 +40,13 @@ ApplyBackend = Literal["auto", "scipy", "numba", "cupy"]
 
 # Ad-hoc key names used for healpix attrs
 HEALPIX_LEVEL: Final = "healpix_level"
-"""\"Healpix_level\" is equivalent in CF vocabulary to refinement_level."""
+"""\"healpix_level\" is equivalent in CF vocabulary to refinement_level."""
 
 HEALPIX_NSIDE: Final = "healpix_nside"
 """\"healpix_nside\" is the number of pixels per size in, not required by the healpix CF convention."""
 
 HEALPIX_ORDER: Final = "healpix_order"
-"""\"Healpix_order\" is equivalent in CF vocabulary to indexing_scheme."""
-
+"""\"healpix_order\" is equivalent in CF vocabulary to indexing_scheme."""
 
 class ZarrOptions(TypedDict, total=False):
     """Definitions of possible to_zarr arguments."""

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -38,9 +38,6 @@ MissingPolicy = Literal["renormalize", "propagate"]
 ApplyBackend = Literal["auto", "scipy", "numba", "cupy"]
 """Which application backend to use."""
 
-HealpixIndexScheme = Literal["nested", "ring", "zuniq", "nuniq"]
-"""Allowed Healpix indexing schemes."""
-
 
 class ZarrOptions(TypedDict, total=False):
     """Definitions of possible to_zarr arguments."""

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -48,7 +48,7 @@ HEALPIX_NSIDE: Final = "healpix_nside"
 HEALPIX_ORDER: Final = "healpix_order"
 """\"healpix_order\" is equivalent in CF vocabulary to indexing_scheme."""
 
-HEALPIX_INDEX: Final = "cell"
+HEALPIX_INDEX: Final = "healpix_index"
 """The default NON-STANDARD name for the healpix index coordinate."""
 
 

--- a/src/grid_doctor/types.py
+++ b/src/grid_doctor/types.py
@@ -48,6 +48,10 @@ HEALPIX_NSIDE: Final = "healpix_nside"
 HEALPIX_ORDER: Final = "healpix_order"
 """\"healpix_order\" is equivalent in CF vocabulary to indexing_scheme."""
 
+HEALPIX_INDEX: Final = "cell"
+"""The default NON-STANDARD name for the healpix index coordinate."""
+
+
 class ZarrOptions(TypedDict, total=False):
     """Definitions of possible to_zarr arguments."""
 

--- a/src/grid_doctor/utils.py
+++ b/src/grid_doctor/utils.py
@@ -14,7 +14,7 @@ from typing import Any, Collection, Literal, cast
 import numpy as np
 import xarray as xr
 
-from .types import RemapMethod, SourceUnits
+from .types import HEALPIX_INDEX, RemapMethod, SourceUnits
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ def chunk_for_target_store_size(
     Returns
     -------
     dict[str, int]
-        Chunk sizes, e.g. {"time": 5, "cell": 786432}.
+        Chunk sizes, e.g. {"time": 5, "healpix_index": 786432}.
     """
     nside = 2**level
     ncell = 12 * nside * nside
@@ -68,7 +68,7 @@ def chunk_for_target_store_size(
     if access == "map":
         cell_chunk = ncell if max_cell_chunk is None else min(ncell, max_cell_chunk)
         time_chunk = max(1, target_uncompressed_bytes // (itemsize * cell_chunk))
-        return {"time": int(time_chunk), "cell": int(cell_chunk)}
+        return {"time": int(time_chunk), HEALPIX_INDEX: int(cell_chunk)}
 
     if access == "time_series":
         if max_time_chunk is not None:
@@ -89,7 +89,7 @@ def chunk_for_target_store_size(
         if max_cell_chunk is not None:
             cell_chunk = min(cell_chunk, max_cell_chunk)
 
-        return {"time": int(time_chunk), "cell": int(cell_chunk)}
+        return {"time": int(time_chunk), HEALPIX_INDEX: int(cell_chunk)}
 
     raise ValueError(f"Unsupported access mode: {access!r}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from grid_doctor.types import HEALPIX_INDEX
 
 def _xy_to_latlon(
     x: np.ndarray,
@@ -168,12 +169,12 @@ def healpix_ds() -> xr.Dataset:
     lon = np.linspace(-180.0, 180.0, npix, endpoint=False)
     rng = np.random.default_rng(99)
     return xr.Dataset(
-        {"temperature": (("time", "cell"), rng.random((2, npix)).astype("float32"))},
+        {"temperature": (("time", HEALPIX_INDEX), rng.random((2, npix)).astype("float32"))},
         coords={
             "time": np.arange(2),
-            "cell": np.arange(npix),
-            "latitude": ("cell", lat),
-            "longitude": ("cell", lon),
+            HEALPIX_INDEX: np.arange(npix),
+            "latitude": (HEALPIX_INDEX, lat),
+            "longitude": (HEALPIX_INDEX, lon),
         },
         attrs={"healpix_nside": 2**level, "healpix_level": level, "healpix_order": "nested"},
     )

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1,0 +1,100 @@
+"""Tests for `grid_doctor.cf`."""
+
+from __future__ import annotations
+
+import pytest
+
+from grid_doctor.cf import (
+    _healpix_cf_attrs,
+    CFKey,
+)
+
+# ===================================================================
+#
+# ===================================================================
+
+
+class TestCFAttributes:
+    @pytest.mark.parametrize(
+        "scheme,level,expected",
+        [
+            (
+                "ring",
+                0,
+                {
+                    "grid_mapping_name": "healpix",
+                    "indexing_scheme": "ring",
+                    "refinement_level": "0",
+                },
+            ),
+            (
+                "nested",
+                1,
+                {
+                    "grid_mapping_name": "healpix",
+                    "indexing_scheme": "nested",
+                    "refinement_level": "1",
+                },
+            ),
+            (
+                "nuniq",
+                2,
+                {
+                    "grid_mapping_name": "healpix",
+                    "indexing_scheme": "nuniq",
+                },
+            ),
+            (
+                "zuniq",
+                None,
+                {
+                    "grid_mapping_name": "healpix",
+                    "indexing_scheme": "zuniq",
+                },
+            ),
+        ],
+        ids=["ring", "nested", "nuniq", "zuniq"],
+    )
+    def test_healpix_cf_attrs(self, scheme, level, expected) -> None:
+        r = _healpix_cf_attrs(scheme, level)
+        assert r == expected
+
+    @pytest.mark.parametrize(
+        "level,match",
+        [
+            (0.0, r"Cannot set invalid refinement level: '0.0' \(must be integer\)\."),
+            ("0", r"Cannot set invalid refinement level: '0' \(must be integer\)\."),
+            (-1, r"Cannot set negative refinement level: '-1'"),
+        ],
+        ids=["float", "str", "-negative"],
+    )
+    def test_healpix_cf_attrs_error_level(self, level, match) -> None:
+        with pytest.raises(ValueError, match=match):
+            _healpix_cf_attrs("ring", level)
+
+    @pytest.mark.parametrize(
+        "scheme,match",
+        [
+            ("RING", r"Cannot attach unsupported scheme.*"),
+        ],
+        ids=[
+            "upper",
+        ],
+    )
+    def test_healpix_cf_attrs_error_scheme(self, scheme, match) -> None:
+        with pytest.raises(ValueError, match=match):
+            _healpix_cf_attrs(scheme, 0)
+
+    @pytest.mark.parametrize(
+        "scheme",
+        [
+            "ring",
+            "nested",
+        ],
+    )
+    def test_healpix_cf_attr_mandatory_level(self, scheme):
+        with pytest.raises(
+            ValueError,
+            match=f"Indexing scheme {scheme} requires a valid healpix refinement level.",
+        ):
+            _healpix_cf_attrs(scheme, None)

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -6,95 +6,81 @@ import pytest
 
 from grid_doctor.cf import (
     _healpix_cf_attrs,
-    CFKey,
+    CFHealpixGridAttrs,
 )
 
 # ===================================================================
-#
+# Test CFHealpixGridAttrs
 # ===================================================================
 
 
-class TestCFAttributes:
+class TestCFHealpixGridAttrs:
     @pytest.mark.parametrize(
-        "scheme,level,expected",
+        "scheme, level", [("nested", 1), ("ring", 2), ("zuniq", None), ("nuniq", None)]
+    )
+    def test_construct(self, scheme, level):
+        attrs = CFHealpixGridAttrs(indexing_scheme=scheme, refinement_level=level)
+        assert attrs.indexing_scheme == scheme
+        assert attrs.refinement_level == level
+        assert attrs.grid_mapping_name == "healpix"
+
+    @pytest.mark.parametrize(
+        "scheme,level,msg",
         [
             (
-                "ring",
-                0,
-                {
-                    "grid_mapping_name": "healpix",
-                    "indexing_scheme": "ring",
-                    "refinement_level": "0",
-                },
-            ),
-            (
                 "nested",
+                "1",
+                "Invalid `refinement_level`: '1'; Must be integer."
+            ),
+            ("ring", -1, "Cannot set negative `refinement_level`: '-1'."),
+            (
+                "zuniq",
                 1,
-                {
-                    "grid_mapping_name": "healpix",
-                    "indexing_scheme": "nested",
-                    "refinement_level": "1",
-                },
+                "`refinement_level` cannot be specified when `indexing_scheme` is 'zuniq'.",
             ),
             (
                 "nuniq",
-                2,
-                {
-                    "grid_mapping_name": "healpix",
-                    "indexing_scheme": "nuniq",
-                },
-            ),
-            (
-                "zuniq",
-                None,
-                {
-                    "grid_mapping_name": "healpix",
-                    "indexing_scheme": "zuniq",
-                },
+                0.2,
+                "`refinement_level` cannot be specified when `indexing_scheme` is 'nuniq'.",
             ),
         ],
-        ids=["ring", "nested", "nuniq", "zuniq"],
     )
-    def test_healpix_cf_attrs(self, scheme, level, expected) -> None:
-        r = _healpix_cf_attrs(scheme, level)
-        assert r == expected
+    def test_invalid_construct(self, scheme, level, msg):
+        with pytest.raises(ValueError, match=msg):
+            CFHealpixGridAttrs(indexing_scheme=scheme, refinement_level=level)
 
-    @pytest.mark.parametrize(
-        "level,match",
-        [
-            (0.0, r"Cannot set invalid refinement level: '0.0' \(must be integer\)\."),
-            ("0", r"Cannot set invalid refinement level: '0' \(must be integer\)\."),
-            (-1, r"Cannot set negative refinement level: '-1'"),
-        ],
-        ids=["float", "str", "-negative"],
-    )
-    def test_healpix_cf_attrs_error_level(self, level, match) -> None:
-        with pytest.raises(ValueError, match=match):
-            _healpix_cf_attrs("ring", level)
-
-    @pytest.mark.parametrize(
-        "scheme,match",
-        [
-            ("RING", r"Cannot attach unsupported scheme.*"),
-        ],
-        ids=[
-            "upper",
-        ],
-    )
-    def test_healpix_cf_attrs_error_scheme(self, scheme, match) -> None:
-        with pytest.raises(ValueError, match=match):
-            _healpix_cf_attrs(scheme, 0)
-
-    @pytest.mark.parametrize(
-        "scheme",
-        [
-            "ring",
-            "nested",
-        ],
-    )
-    def test_healpix_cf_attr_mandatory_level(self, scheme):
+    @pytest.mark.parametrize("scheme", ["nested", "ring"])
+    def test_mandatory_level_construct(self, scheme):
         with pytest.raises(
             ValueError,
-            match=f"Indexing scheme {scheme} requires a valid healpix refinement level.",
+            match=f"Indexing scheme {scheme!r} requires a `refinement_level` to be set."
         ):
-            _healpix_cf_attrs(scheme, None)
+            CFHealpixGridAttrs(indexing_scheme=scheme)
+
+    @pytest.mark.parametrize("scheme", ["zuniq", "nuniq"])
+    def test_optional_level_construct(self, scheme):
+        attrs = CFHealpixGridAttrs(indexing_scheme=scheme)
+        assert attrs.grid_mapping_name == "healpix"
+        assert attrs.refinement_level == None
+        assert attrs.indexing_scheme == scheme
+
+    @pytest.mark.parametrize("scheme", ["NESTED", "bad"])
+    def test_unknown_scheme(self, scheme):
+        with pytest.raises(
+            ValueError,
+            match=r"`indexing_scheme` must be one of \['nested', 'nuniq', 'ring', 'zuniq'\], not "
+            + f"{scheme!r}",
+        ):
+            CFHealpixGridAttrs(indexing_scheme=scheme)
+
+
+class TestDictIntegrationCFHealpixGridAttrs:
+    @pytest.mark.parametrize(
+        "scheme, level", [("nested", 1), ("ring", 2), ("zuniq", None), ("nuniq", None)]
+    )
+    def test_dict_construct(self, scheme, level):
+        attrs = CFHealpixGridAttrs(indexing_scheme=scheme, refinement_level=level)
+        expected = {"grid_mapping_name": "healpix", "indexing_scheme": scheme} | (
+            {"refinement_level": level} if level else {}
+        )
+        assert dict(attrs) == expected

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from dataclasses import FrozenInstanceError
 from grid_doctor.cf import (
     _healpix_cf_attrs,
     CFConventions,
@@ -86,6 +87,12 @@ class TestCFHealpixGridAttrs:
         attrs = CFHealpixGridAttrs(indexing_scheme='zuniq')
         assert attrs.earth_radius is not None
         assert attrs.earth_radius == 6371009
+
+    def test_immutability(self):
+        with pytest.raises(FrozenInstanceError, match = r"cannot assign to field 'scheme'"):
+            attrs = CFHealpixGridAttrs(indexing_scheme='zuniq')
+            attrs.scheme = 'bad'
+
 
 
 class TestDictIntegrationCFHealpixGridAttrs:

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -6,8 +6,17 @@ import pytest
 
 from grid_doctor.cf import (
     _healpix_cf_attrs,
+    CFConventions,
     CFHealpixGridAttrs,
 )
+
+
+class TestCFConventions:
+    def test_version(self):
+        cf = CFConventions()
+        assert cf.Conventions == 'CF-1.13'
+        assert cf.to_dict() == { 'Conventions': 'CF-1.13' }
+
 
 # ===================================================================
 # Test CFHealpixGridAttrs

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -105,6 +105,7 @@ class TestDictIntegrationCFHealpixGridAttrs:
             {"refinement_level": level} if level else {}
         )
         assert dict(attrs) == expected
+        assert attrs.to_dict()== expected
 
     def test_dict_no_radius(self):
         attrs = CFHealpixGridAttrs(indexing_scheme='zuniq',earth_radius=None)

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -73,6 +73,11 @@ class TestCFHealpixGridAttrs:
         ):
             CFHealpixGridAttrs(indexing_scheme=scheme)
 
+    def test_earth_radius(self):
+        attrs = CFHealpixGridAttrs(indexing_scheme='zuniq')
+        assert attrs.earth_radius is not None
+        assert attrs.earth_radius == 6371009
+
 
 class TestDictIntegrationCFHealpixGridAttrs:
     @pytest.mark.parametrize(
@@ -80,7 +85,11 @@ class TestDictIntegrationCFHealpixGridAttrs:
     )
     def test_dict_construct(self, scheme, level):
         attrs = CFHealpixGridAttrs(indexing_scheme=scheme, refinement_level=level)
-        expected = {"grid_mapping_name": "healpix", "indexing_scheme": scheme} | (
+        expected = {"grid_mapping_name": "healpix", "indexing_scheme": scheme, "earth_radius": 6371009 } | (
             {"refinement_level": level} if level else {}
         )
         assert dict(attrs) == expected
+
+    def test_dict_no_radius(self):
+        attrs = CFHealpixGridAttrs(indexing_scheme='zuniq',earth_radius=None)
+        assert 'earth_radius' not in dict(attrs)

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -6,7 +6,7 @@ import pytest
 
 from dataclasses import FrozenInstanceError
 from grid_doctor.cf import (
-    _healpix_cf_attrs,
+    healpix_grid_mapping_attrs,
     CFConventions,
     CFHealpixGridAttrs,
 )

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -88,6 +88,10 @@ class TestCFHealpixGridAttrs:
         assert attrs.earth_radius is not None
         assert attrs.earth_radius == 6371009
 
+    def test_bad_earth_radius(self):
+        with pytest.raises(ValueError, match=f"Invalid `earth_radius`: '1'; Must be integer, in meters!"):
+            CFHealpixGridAttrs(indexing_scheme='nuniq', earth_radius='1')
+
     def test_immutability(self):
         with pytest.raises(FrozenInstanceError, match = r"cannot assign to field 'scheme'"):
             attrs = CFHealpixGridAttrs(indexing_scheme='zuniq')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -177,9 +177,10 @@ class TestCoarsenHealpix:
         coarse = coarsen_healpix(healpix_ds, target_level=1)
         assert coarse.sizes["cell"] == 48
         assert coarse.attrs["healpix_level"] == 1
-        assert coarse.attrs["grid_mapping_name"] == "healpix"
-        assert coarse.attrs["refinement_level"] == 1
-        assert coarse.attrs["indexing_scheme"] == "nested"
+
+        assert "grid_mapping_name" not in coarse.attrs
+        assert "refinement_level" not in coarse.attrs
+        assert "indexing_scheme" not in coarse.attrs
 
         assert "Conventions" in coarse.attrs
         assert coarse.attrs["Conventions"] == "CF-1.13"
@@ -302,11 +303,12 @@ class TestCoarsenHealpix:
         assert coarse.coords["crs"].attrs["indexing_scheme"] == "nested"
         assert coarse.coords["crs"].attrs["earth_radius"] == 6371009
 
-        assert coarse.attrs["grid_mapping_name"] == "healpix"
-        assert coarse.attrs["refinement_level"] == 1
-        assert coarse.attrs["indexing_scheme"] == "nested"
         assert 'Conventions' in coarse.attrs
         assert coarse.attrs['Conventions'] == 'CF-1.13'
+
+        assert "grid_mapping_name" not in coarse.attrs
+        assert "refinement_level" not in coarse.attrs
+        assert "indexing_scheme" not in coarse.attrs
 
 
     def test_data_vars_have_grid_mapping(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,6 +23,7 @@ from grid_doctor.helpers import (
     resolution_to_healpix_level,
     save_pyramid,
 )
+from grid_doctor.types import HEALPIX_INDEX
 
 
 class TestGridDetection:
@@ -175,7 +176,7 @@ class TestCoarsenHealpix:
             lambda level, nest: (np.array([0.0] * 48), np.array([1.0] * 48)),
         )
         coarse = coarsen_healpix(healpix_ds, target_level=1)
-        assert coarse.sizes["cell"] == 48
+        assert coarse.sizes[HEALPIX_INDEX] == 48
         assert coarse.attrs["healpix_level"] == 1
 
         assert "grid_mapping_name" not in coarse.attrs

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -283,6 +283,37 @@ class TestCoarsenHealpix:
             "Cells with only 4/16 valid children should be NaN"
         )
 
+    def test_has_cf_attrs(
+        self, healpix_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            helpers,
+            "_healpix_coords",
+            lambda level, nest: (np.array([0.0] * 48), np.array([1.0] * 48)),
+        )
+        coarse = coarsen_healpix(healpix_ds, target_level=1)
+        assert "crs" in coarse.coords
+        assert coarse.coords["crs"].attrs["grid_mapping_name"] == "healpix"
+        assert coarse.coords["crs"].attrs["refinement_level"] == 1
+        assert coarse.coords["crs"].attrs["indexing_scheme"] == "nested"
+        assert coarse.coords["crs"].attrs["earth_radius"] == 6371009
+
+        for name in coarse.data_vars:
+            if "cell" in coarse[name].dims:
+                assert coarse[name].attrs["grid_mapping"] == "crs"
+                assert "grid_mapping_name" not in coarse[name].attrs
+                assert "refinement_level" not in coarse[name].attrs
+                assert "indexing_scheme" not in coarse[name].attrs
+
+
+        assert 'Conventions' in coarse.attrs
+        assert coarse.attrs['Conventions'] == 'CF-1.13'
+
+        assert "grid_mapping_name" not in coarse.attrs
+        assert "refinement_level" not in coarse.attrs
+        assert "indexing_scheme" not in coarse.attrs
+
+
     def test_has_crs_variable(
         self, healpix_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -293,6 +293,10 @@ class TestCoarsenHealpix:
         assert coarse.coords["crs"].attrs["healpix_level"] == 1
         assert coarse.coords["crs"].attrs["healpix_order"] == "nested"
 
+        assert coarse.coords["crs"].attrs["grid_mapping_name"] == "healpix"
+        assert coarse.coords["crs"].attrs["refinement_level"] == "1"
+        assert coarse.coords["crs"].attrs["indexing_scheme"] == "nested"
+
         assert coarse.attrs["grid_mapping_name"] == "healpix"
         assert coarse.attrs["refinement_level"] == "1"
         assert coarse.attrs["indexing_scheme"] == "nested"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -296,10 +296,12 @@ class TestCoarsenHealpix:
         assert coarse.coords["crs"].attrs["grid_mapping_name"] == "healpix"
         assert coarse.coords["crs"].attrs["refinement_level"] == 1
         assert coarse.coords["crs"].attrs["indexing_scheme"] == "nested"
+        assert coarse.coords["crs"].attrs["earth_radius"] == 6371009
 
         assert coarse.attrs["grid_mapping_name"] == "healpix"
         assert coarse.attrs["refinement_level"] == 1
         assert coarse.attrs["indexing_scheme"] == "nested"
+
 
     def test_data_vars_have_grid_mapping(
         self, healpix_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -178,7 +178,7 @@ class TestCoarsenHealpix:
         assert coarse.sizes["cell"] == 48
         assert coarse.attrs["healpix_level"] == 1
         assert coarse.attrs["grid_mapping_name"] == "healpix"
-        assert coarse.attrs["refinement_level"] == "1"
+        assert coarse.attrs["refinement_level"] == 1
         assert coarse.attrs["indexing_scheme"] == "nested"
 
     def test_rejects_ring_order(self, healpix_ds: xr.Dataset) -> None:
@@ -294,11 +294,11 @@ class TestCoarsenHealpix:
         assert coarse.coords["crs"].attrs["healpix_order"] == "nested"
 
         assert coarse.coords["crs"].attrs["grid_mapping_name"] == "healpix"
-        assert coarse.coords["crs"].attrs["refinement_level"] == "1"
+        assert coarse.coords["crs"].attrs["refinement_level"] == 1
         assert coarse.coords["crs"].attrs["indexing_scheme"] == "nested"
 
         assert coarse.attrs["grid_mapping_name"] == "healpix"
-        assert coarse.attrs["refinement_level"] == "1"
+        assert coarse.attrs["refinement_level"] == 1
         assert coarse.attrs["indexing_scheme"] == "nested"
 
     def test_data_vars_have_grid_mapping(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -193,6 +193,13 @@ class TestCoarsenHealpix:
         with pytest.raises(ValueError, match="only supports nested"):
             coarsen_healpix(ds, target_level=1)
 
+    def test_rejects_higher_level(self, healpix_ds: xr.Dataset) -> None:
+        ds = healpix_ds.copy()
+        ds.attrs["healpix_level"] = 0
+        ds.attrs["healpix_nside"] = 2**0
+        with pytest.raises(ValueError, match="lower than the current HEALPix level."):
+            coarsen_healpix(ds, target_level=1)
+
     def test_preserves_non_cell_variable(
         self, healpix_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -177,6 +177,9 @@ class TestCoarsenHealpix:
         coarse = coarsen_healpix(healpix_ds, target_level=1)
         assert coarse.sizes["cell"] == 48
         assert coarse.attrs["healpix_level"] == 1
+        assert coarse.attrs["grid_mapping_name"] == "healpix"
+        assert coarse.attrs["refinement_level"] == "1"
+        assert coarse.attrs["indexing_scheme"] == "nested"
 
     def test_rejects_ring_order(self, healpix_ds: xr.Dataset) -> None:
         ds = healpix_ds.copy()
@@ -289,6 +292,10 @@ class TestCoarsenHealpix:
         assert coarse.coords["crs"].attrs["healpix_nside"] == 2
         assert coarse.coords["crs"].attrs["healpix_level"] == 1
         assert coarse.coords["crs"].attrs["healpix_order"] == "nested"
+
+        assert coarse.attrs["grid_mapping_name"] == "healpix"
+        assert coarse.attrs["refinement_level"] == "1"
+        assert coarse.attrs["indexing_scheme"] == "nested"
 
     def test_data_vars_have_grid_mapping(
         self, healpix_ds: xr.Dataset, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -181,6 +181,10 @@ class TestCoarsenHealpix:
         assert coarse.attrs["refinement_level"] == 1
         assert coarse.attrs["indexing_scheme"] == "nested"
 
+        assert "Conventions" in coarse.attrs
+        assert coarse.attrs["Conventions"] == "CF-1.13"
+
+
     def test_rejects_ring_order(self, healpix_ds: xr.Dataset) -> None:
         ds = healpix_ds.copy()
         ds.attrs["healpix_order"] = "ring"
@@ -301,6 +305,8 @@ class TestCoarsenHealpix:
         assert coarse.attrs["grid_mapping_name"] == "healpix"
         assert coarse.attrs["refinement_level"] == 1
         assert coarse.attrs["indexing_scheme"] == "nested"
+        assert 'Conventions' in coarse.attrs
+        assert coarse.attrs['Conventions'] == 'CF-1.13'
 
 
     def test_data_vars_have_grid_mapping(

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -12,7 +12,7 @@ import xarray as xr
 from grid_doctor import remap
 from grid_doctor.helpers import latlon_to_healpix_pyramid
 from grid_doctor.remap import regrid_to_healpix
-
+from grid_doctor.types import HEALPIX_INDEX
 
 @pytest.mark.parametrize("method", ["nearest", "conservative"])
 def test_latlon_to_healpix_pyramid_weight_methods(
@@ -25,7 +25,7 @@ def test_latlon_to_healpix_pyramid_weight_methods(
         del kwargs
         return xr.Dataset(
             {
-                name: (("cell",), np.arange(12 * (4**level), dtype=np.float64))
+                name: ((HEALPIX_INDEX,), np.arange(12 * (4**level), dtype=np.float64))
                 for name in ds.data_vars
             },
             attrs=ds.attrs

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -687,3 +687,6 @@ class TestAttachHealpixCoords:
         assert result.attrs["grid_mapping_name"] == "healpix"
         assert result.attrs["indexing_scheme"] == "ring"
         assert result.attrs["refinement_level"] == level
+
+        assert "Conventions" in result.attrs
+        assert result.attrs["Conventions"] == "CF-1.13"

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -684,9 +684,10 @@ class TestAttachHealpixCoords:
         assert "longitude" in result.coords
         assert result.attrs["healpix_nside"] == 4
         assert result.attrs["healpix_order"] == "ring"
-        assert result.attrs["grid_mapping_name"] == "healpix"
-        assert result.attrs["indexing_scheme"] == "ring"
-        assert result.attrs["refinement_level"] == level
 
         assert "Conventions" in result.attrs
         assert result.attrs["Conventions"] == "CF-1.13"
+
+        assert "grid_mapping_name" not in result.attrs
+        assert "indexing_scheme" not in result.attrs
+        assert "refinement_level" not in result.attrs

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -31,6 +31,7 @@ from grid_doctor.remap_backend import (
     _normalise_angle_units,
     _regular_grid_mesh,
 )
+from grid_doctor.types import HEALPIX_INDEX
 from .helpers import _FakeHealpixModule
 
 
@@ -434,8 +435,15 @@ class TestApplyWeightFile:
 
         result = apply_weight_file(ds, path, missing_policy="renormalize")
 
-        assert "cell" in result.dims
-        assert result.sizes["cell"] == 2
+        if "cell" != HEALPIX_INDEX:
+            # cell should disappear or be overwritten
+            assert "cell" not in result.dims
+            assert "cell" not in result
+            assert "cell" not in result.coords
+            assert "cell" not in result.indexes
+            assert "cell" not in result.data_vars
+        assert HEALPIX_INDEX in result.dims
+        assert result.sizes[HEALPIX_INDEX] == 2
         out = result["temperature"].isel(time=0, level=0).values
         np.testing.assert_allclose(out, [1.0, 3.0])
         np.testing.assert_allclose(result["static"].values, ds["static"].values)
@@ -483,7 +491,15 @@ class TestApplyWeightFile:
             path,
             source_dims=("cell",),
         )
-        assert result.sizes["cell"] == 2
+        if "cell" != HEALPIX_INDEX:
+            # cell should disappear or be overwritten
+            assert "cell" not in result.dims
+            assert "cell" not in result
+            assert "cell" not in result.coords
+            assert "cell" not in result.indexes
+            assert "cell" not in result.data_vars
+        assert HEALPIX_INDEX in result.dims
+        assert result.sizes[HEALPIX_INDEX] == 2
         out = result["temperature"].isel(time=0).values
         np.testing.assert_allclose(out, [1.0, 3.0])
 

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -678,8 +678,12 @@ class TestAttachHealpixCoords:
             ),
         )
         ds = xr.Dataset({"t": ("cell", np.array([1.0, 2.0]))})
-        result = _attach_healpix_coords(ds, level=2, nest=False)
+        level = 2
+        result = _attach_healpix_coords(ds, level=level, nest=False)
         assert "latitude" in result.coords
         assert "longitude" in result.coords
         assert result.attrs["healpix_nside"] == 4
         assert result.attrs["healpix_order"] == "ring"
+        assert result.attrs["grid_mapping_name"] == "healpix"
+        assert result.attrs["indexing_scheme"] == "ring"
+        assert result.attrs["refinement_level"] == str(level)

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -686,4 +686,4 @@ class TestAttachHealpixCoords:
         assert result.attrs["healpix_order"] == "ring"
         assert result.attrs["grid_mapping_name"] == "healpix"
         assert result.attrs["indexing_scheme"] == "ring"
-        assert result.attrs["refinement_level"] == str(level)
+        assert result.attrs["refinement_level"] == level

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -16,6 +16,7 @@ from grid_doctor import (
 )
 from grid_doctor.helpers import WRITE_COORDS_MAX_LEVEL
 from grid_doctor.select import _contiguous_runs, _parents_to_ranges
+from grid_doctor.types import HEALPIX_INDEX
 
 LEVEL = 8
 DELTA = 4
@@ -35,10 +36,10 @@ def _centres(cells: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 
 @pytest.fixture
 def dense_ds() -> xr.Dataset:
-    """Dense global dataset whose values encode the cell index."""
+    """Dense global dataset whose values encode the healpix index."""
     data = (np.arange(NPIX) % 97).astype(np.float32)
     return xr.Dataset(
-        {"t2m": ("cell", data)},
+        {"t2m": (HEALPIX_INDEX, data)},
         attrs={
             "healpix_level": LEVEL,
             "healpix_nside": 2**LEVEL,
@@ -67,7 +68,7 @@ class TestSelectCells:
     def test_positional_dense_selection(self, dense_ds: xr.Dataset) -> None:
         cells = np.array([0, 1, 2, 100, 5000], dtype=np.int64)
         result = select_cells(dense_ds, cells)
-        assert (result["cell"].values == cells).all()
+        assert (result[HEALPIX_INDEX].values == cells).all()
         assert np.allclose(result["t2m"].values, cells % 97)
 
     def test_coords_are_reconstructed(self, dense_ds: xr.Dataset) -> None:
@@ -116,8 +117,8 @@ class TestSelectCells:
         ds = dense_ds.copy()
         ds["t2m"] = ds["t2m"].expand_dims(time=[0, 1])
         result = select_cells(ds, np.array([10, 11]))
-        assert result["t2m"].dims == ("time", "cell")
-        assert result.sizes == {"time": 2, "cell": 2}
+        assert result["t2m"].dims == ("time", HEALPIX_INDEX)
+        assert result.sizes == {"time": 2, HEALPIX_INDEX: 2}
 
 
 class TestSelectBbox:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -101,11 +101,11 @@ class TestSelectCells:
             select_cells(dense_ds, np.array([], dtype=np.int64))
 
     def test_missing_level_attribute_raises(self) -> None:
-        ds = xr.Dataset({"t2m": ("cell", np.zeros(12))})
+        ds = xr.Dataset({"t2m": (HEALPIX_INDEX, np.zeros(12))})
         with pytest.raises(ValueError, match="healpix_level"):
             select_cells(ds, np.array([0]))
         result = select_cells(ds, np.array([0]), level=0)
-        assert result.sizes["cell"] == 1
+        assert result.sizes[HEALPIX_INDEX] == 1
 
     def test_ring_ordering_rejected(self, dense_ds: xr.Dataset) -> None:
         ds = dense_ds.copy()
@@ -134,8 +134,8 @@ class TestSelectBbox:
             & (lat > BBOX_LAT[0])
             & (lat < BBOX_LAT[1])
         )
-        assert np.isin(np.nonzero(inside)[0], result["cell"].values).all()
-        assert np.allclose(result["t2m"].values, result["cell"].values % 97)
+        assert np.isin(np.nonzero(inside)[0], result[HEALPIX_INDEX].values).all()
+        assert np.allclose(result["t2m"].values, result[HEALPIX_INDEX].values % 97)
 
     def test_selection_is_local(self, dense_ds: xr.Dataset) -> None:
         """The covering superset stays within one parent cell of the box."""
@@ -146,16 +146,16 @@ class TestSelectBbox:
         lat = result["latitude"].values
         assert lat.min() > BBOX_LAT[0] - 2 * parent_spacing
         assert lat.max() < BBOX_LAT[1] + 2 * parent_spacing
-        assert result.sizes["cell"] < NPIX // 100
+        assert result.sizes[HEALPIX_INDEX] < NPIX // 100
 
     def test_query_delta_alignment(self, dense_ds: xr.Dataset) -> None:
         """Selected cells arrive in whole parent blocks of 4**delta."""
         result = select_bbox(
             dense_ds, lon=BBOX_LON, lat=BBOX_LAT, query_delta=DELTA
         )
-        assert result.sizes["cell"] % 4**DELTA == 0
-        parents = np.unique(result["cell"].values >> (2 * DELTA))
-        assert result.sizes["cell"] == parents.size * 4**DELTA
+        assert result.sizes[HEALPIX_INDEX] % 4**DELTA == 0
+        parents = np.unique(result[HEALPIX_INDEX].values >> (2 * DELTA))
+        assert result.sizes[HEALPIX_INDEX] == parents.size * 4**DELTA
 
 
 class TestSelectCone:
@@ -168,8 +168,8 @@ class TestSelectCone:
         result = select_cone(
             dense_ds, lon=13.4, lat=52.5, radius=0.5, query_delta=DELTA
         )
-        assert int(centre) in result["cell"].values
-        assert np.allclose(result["t2m"].values, result["cell"].values % 97)
+        assert int(centre) in result[HEALPIX_INDEX].values
+        assert np.allclose(result["t2m"].values, result[HEALPIX_INDEX].values % 97)
 
 
 class TestWriteCoords:
@@ -189,7 +189,7 @@ class TestWriteCoords:
         )
         opened = xr.open_zarr(tmp_path / f"level_{LEVEL}.zarr", chunks=None)
         assert "latitude" not in opened and "longitude" not in opened
-        assert "cell" not in opened.coords
+        assert HEALPIX_INDEX not in opened.coords
         assert "crs" in opened.coords
         assert int(opened.attrs["grid_doctor_implicit_coords"]) == 1
         assert opened.attrs["healpix_level"] == LEVEL
@@ -203,7 +203,7 @@ class TestWriteCoords:
             write_coords=True,
         )
         opened = xr.open_zarr(tmp_path / f"level_{LEVEL}.zarr", chunks=None)
-        assert {"latitude", "longitude", "cell"} <= set(opened.coords)
+        assert {"latitude", "longitude", HEALPIX_INDEX} <= set(opened.coords)
         assert "grid_doctor_implicit_coords" not in opened.attrs
 
     def test_auto_uses_level_threshold(
@@ -232,5 +232,5 @@ class TestWriteCoords:
         region = select_bbox(
             opened, lon=BBOX_LON, lat=BBOX_LAT, query_delta=DELTA
         )
-        assert np.allclose(region["t2m"].values, region["cell"].values % 97)
+        assert np.allclose(region["t2m"].values, region[HEALPIX_INDEX].values % 97)
         assert int(region.attrs["grid_doctor_sparse"]) == 1

--- a/tests/test_swath.py
+++ b/tests/test_swath.py
@@ -17,6 +17,7 @@ from grid_doctor.swath.utils import (
     masked_float64,
     resolve_point_coords,
 )
+from grid_doctor.types import HEALPIX_INDEX
 
 LEVEL = 4
 NPIX = 12 * 4**LEVEL
@@ -215,7 +216,7 @@ class TestBinToHealpixDense:
         self, swath_ds: xr.Dataset, target_cells: np.ndarray
     ) -> None:
         result = bin_to_healpix(swath_ds, LEVEL)
-        assert result.sizes["cell"] == NPIX
+        assert result.sizes[HEALPIX_INDEX] == NPIX
         assert np.allclose(
             result["field"].values[target_cells], np.arange(len(target_cells))
         )
@@ -240,7 +241,7 @@ class TestBinToHealpixDense:
         stacked.loc[{"time": 1}] = stacked.sel(time=1) + 10.0
         ds = ds.assign(field=stacked)
         result = bin_to_healpix(ds, LEVEL)
-        assert result["field"].dims == ("time", "cell")
+        assert result["field"].dims == ("time", HEALPIX_INDEX)
         assert np.allclose(
             result["field"].values[1, target_cells]
             - result["field"].values[0, target_cells],
@@ -355,8 +356,8 @@ class TestBinToHealpixSparse:
         self, swath_ds: xr.Dataset, target_cells: np.ndarray
     ) -> None:
         result = bin_to_healpix(swath_ds, LEVEL, dense=False)
-        assert result.sizes["cell"] == len(target_cells)
-        assert (np.sort(result["cell"].values) == np.sort(target_cells)).all()
+        assert result.sizes[HEALPIX_INDEX] == len(target_cells)
+        assert (np.sort(result[HEALPIX_INDEX].values) == np.sort(target_cells)).all()
         assert int(result.attrs["grid_doctor_sparse"]) == 1
         assert "crs" in result.coords
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from grid_doctor.types import HEALPIX_INDEX
 from grid_doctor.utils import (
     cache_dir,
     cached_open_dataset,
@@ -31,7 +32,7 @@ class TestChunkSizeEstimator:
         target_uncompressed_bytes = int(target_stored_bytes * 2.0)
         expected_time = max(1, target_uncompressed_bytes // (itemsize * ncell))
 
-        assert result == {"time": int(expected_time), "cell": int(ncell)}
+        assert result == {"time": int(expected_time), HEALPIX_INDEX: int(ncell)}
 
     def test_map_respects_max_cell_chunk(self) -> None:
         result = chunk_for_target_store_size(
@@ -44,7 +45,7 @@ class TestChunkSizeEstimator:
         target_uncompressed_bytes = int(target_stored_bytes * 2.0)
         expected_time = max(1, target_uncompressed_bytes // (itemsize * 100_000))
 
-        assert result == {"time": int(expected_time), "cell": 100_000}
+        assert result == {"time": int(expected_time), HEALPIX_INDEX: 100_000}
 
     def test_map_uses_given_dtype(self) -> None:
         result = chunk_for_target_store_size(
@@ -58,7 +59,7 @@ class TestChunkSizeEstimator:
         target_uncompressed_bytes = int(target_stored_bytes * 2.0)
         expected_time = max(1, target_uncompressed_bytes // (itemsize * 50_000))
 
-        assert result == {"time": int(expected_time), "cell": 50_000}
+        assert result == {"time": int(expected_time), HEALPIX_INDEX: 50_000}
 
     def test_time_series_uses_ntime_when_no_max_time_chunk_given(self) -> None:
         result = chunk_for_target_store_size(
@@ -75,7 +76,7 @@ class TestChunkSizeEstimator:
         expected_cell = max(1, target_uncompressed_bytes // (itemsize * 365))
         expected_cell = min(expected_cell, ncell)
 
-        assert result == {"time": 365, "cell": int(expected_cell)}
+        assert result == {"time": 365, HEALPIX_INDEX: int(expected_cell)}
 
     def test_time_series_prefers_max_time_chunk_over_ntime(self) -> None:
         result = chunk_for_target_store_size(
@@ -93,7 +94,7 @@ class TestChunkSizeEstimator:
         expected_cell = max(1, target_uncompressed_bytes // (itemsize * 30))
         expected_cell = min(expected_cell, ncell)
 
-        assert result == {"time": 30, "cell": int(expected_cell)}
+        assert result == {"time": 30, HEALPIX_INDEX: int(expected_cell)}
 
     def test_time_series_caps_max_time_chunk_by_ntime(self) -> None:
         result = chunk_for_target_store_size(
@@ -111,7 +112,7 @@ class TestChunkSizeEstimator:
         expected_cell = max(1, target_uncompressed_bytes // (itemsize * 10))
         expected_cell = min(expected_cell, ncell)
 
-        assert result == {"time": 10, "cell": int(expected_cell)}
+        assert result == {"time": 10, HEALPIX_INDEX: int(expected_cell)}
 
     def test_time_series_respects_max_cell_chunk(self) -> None:
         result = chunk_for_target_store_size(
@@ -122,7 +123,7 @@ class TestChunkSizeEstimator:
         )
 
         assert result["time"] == 365
-        assert result["cell"] == 20_000
+        assert result[HEALPIX_INDEX] == 20_000
 
     def test_time_series_requires_ntime_or_max_time_chunk(self) -> None:
         with pytest.raises(
@@ -143,7 +144,7 @@ class TestChunkSizeEstimator:
         )
 
         assert result["time"] == 1
-        assert result["cell"] == 12 * (2**15) * (2**15)
+        assert result[HEALPIX_INDEX] == 12 * (2**15) * (2**15)
 
     def test_time_series_cell_chunk_is_at_least_one(self) -> None:
         result = chunk_for_target_store_size(
@@ -155,7 +156,7 @@ class TestChunkSizeEstimator:
         )
 
         assert result["time"] == 10_000_000
-        assert result["cell"] == 1
+        assert result[HEALPIX_INDEX] == 1
 
 
 class TestGetS3Options:


### PR DESCRIPTION
This PR adds a new module `cf` to resolve #41
The existing attributes `healpix_{order,nside,level}` are kept, but the equivalent CF ones are added.
